### PR TITLE
tools: EGL/CUDA import checkers — NVIDIA finding for the NVENC validation roadmap item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ modules.builtin
 modules.order
 tools/hermes-kmsctl/hermes-kmsctl
 tools/hermes-kms-import-check/hermes-kms-import-check
+tools/hermes-egl-import-check/hermes-egl-import-check
+tools/hermes-egl-import-check/pitch-detect

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,24 @@ CFLAGS ?= -O2 -g -Wall -Wextra
 UAPI_CFLAGS := -I$(PWD)/include/uapi
 IMPORT_CHECK_CFLAGS := $(shell pkg-config --cflags libva libva-drm libdrm 2>/dev/null)
 IMPORT_CHECK_LIBS := $(shell pkg-config --libs libva libva-drm libdrm 2>/dev/null)
+EGL_CHECK_CFLAGS := $(shell pkg-config --cflags libdrm gbm egl gl 2>/dev/null)
+EGL_CHECK_LIBS := $(shell pkg-config --libs libdrm gbm egl gl 2>/dev/null)
+
+# The CUDA stage of the EGL checker is opt-in: the tool compiles the stage out
+# when HAVE_CUDA is not set, so hosts without the CUDA toolkit still build the
+# full tools target. Enable with `make tools HAVE_CUDA=1` (needs cuda.h,
+# cudaGL.h and libcuda; override CUDA_CFLAGS/CUDA_LIBS for non-default
+# toolkit locations).
+HAVE_CUDA ?= 0
+CUDA_CFLAGS ?=
+CUDA_LIBS ?= -lcuda
+ifeq ($(HAVE_CUDA),1)
+EGL_CHECK_CUDA_CFLAGS := -DHAVE_CUDA $(CUDA_CFLAGS)
+EGL_CHECK_CUDA_LIBS := $(CUDA_LIBS)
+else
+EGL_CHECK_CUDA_CFLAGS :=
+EGL_CHECK_CUDA_LIBS :=
+endif
 UDEV_RULE_DIR ?= /etc/udev/rules.d
 SYSTEM_UDEV_RULE_DIR ?= /usr/lib/udev/rules.d
 
@@ -100,7 +118,8 @@ install-configs:
 	install -Dm0644 packaging/systemd/hermes-kms-seatd@.service \
 		$(DESTDIR)/usr/lib/systemd/system/hermes-kms-seatd@.service
 
-tools: tools/hermes-kmsctl/hermes-kmsctl tools/hermes-kms-import-check/hermes-kms-import-check
+tools: tools/hermes-kmsctl/hermes-kmsctl tools/hermes-kms-import-check/hermes-kms-import-check \
+	tools/hermes-egl-import-check/hermes-egl-import-check tools/hermes-egl-import-check/pitch-detect
 
 tools/hermes-kmsctl/hermes-kmsctl: tools/hermes-kmsctl/hermes_kmsctl.c include/uapi/drm/hermes_kms_drm.h
 	$(CC) $(CFLAGS) $(UAPI_CFLAGS) -o $@ $<
@@ -108,6 +127,14 @@ tools/hermes-kmsctl/hermes-kmsctl: tools/hermes-kmsctl/hermes_kmsctl.c include/u
 tools/hermes-kms-import-check/hermes-kms-import-check: tools/hermes-kms-import-check/hermes_kms_import_check.c include/uapi/drm/hermes_kms_drm.h
 	@test -n "$(IMPORT_CHECK_LIBS)" || { printf 'missing libva/libva-drm/libdrm pkg-config metadata\n' >&2; exit 1; }
 	$(CC) $(CFLAGS) $(UAPI_CFLAGS) $(IMPORT_CHECK_CFLAGS) -o $@ $< $(IMPORT_CHECK_LIBS)
+
+tools/hermes-egl-import-check/hermes-egl-import-check: tools/hermes-egl-import-check/hermes_egl_import_check.c include/uapi/drm/hermes_kms_drm.h
+	@test -n "$(EGL_CHECK_LIBS)" || { printf 'missing libdrm/gbm/egl/gl pkg-config metadata\n' >&2; exit 1; }
+	$(CC) $(CFLAGS) $(UAPI_CFLAGS) $(EGL_CHECK_CFLAGS) $(EGL_CHECK_CUDA_CFLAGS) -o $@ $< $(EGL_CHECK_LIBS) $(EGL_CHECK_CUDA_LIBS)
+
+tools/hermes-egl-import-check/pitch-detect: tools/hermes-egl-import-check/pitch_detect.c include/uapi/drm/hermes_kms_drm.h
+	@test -n "$(EGL_CHECK_LIBS)" || { printf 'missing libdrm/gbm/egl/gl pkg-config metadata\n' >&2; exit 1; }
+	$(CC) $(CFLAGS) $(UAPI_CFLAGS) $(EGL_CHECK_CFLAGS) -o $@ $< $(EGL_CHECK_LIBS)
 
 install-runtime-udev:
 	install -Dm0644 udev/70-hermes-kms-session-seats.rules \
@@ -148,3 +175,5 @@ clean:
 	$(MAKE) -C $(KDIR) M=$(PWD)/kernel/hermes-kms $(LLVM_FLAG) clean
 	$(RM) tools/hermes-kmsctl/hermes-kmsctl
 	$(RM) tools/hermes-kms-import-check/hermes-kms-import-check
+	$(RM) tools/hermes-egl-import-check/hermes-egl-import-check
+	$(RM) tools/hermes-egl-import-check/pitch-detect

--- a/tools/hermes-egl-import-check/README.md
+++ b/tools/hermes-egl-import-check/README.md
@@ -8,12 +8,39 @@ Diagnostic consumers for the NVENC/EGL side of the roadmap item
 Validates the NVENC-style consumer chain for a live Hermes-KMS frame:
 
 ```
-ACQUIRE_FRAME (DMA-BUF) -> eglCreateImage(EGL_LINUX_DMA_BUF_EXT)
+ACQUIRE_FRAME (DMA-BUF) -> wait on the exported sync file
+  -> eglCreateImage(EGL_LINUX_DMA_BUF_EXT)
   -> texture bind (OES, falling back to glEGLImageTargetTexStorageEXT)
   -> FBO readback (proves sampling)
   -> GL blit into an own texture -> cuGraphicsGLRegisterImage
      (mirrors the Sunshine/Hermes CUDA converter flow)
 ```
+
+The tool follows the driver's synchronization contract: a successful
+ACQUIRE_FRAME only means the frame was exported, so the checker waits on the
+returned sync file (the framebuffer's write fence) before reading anything,
+and brackets its CPU reference read with `DMA_BUF_IOCTL_SYNC`.
+
+Every stage is reported individually and summarized at the end:
+
+```
+stage summary:
+  frame acquisition:   PASS
+  fence wait:          PASS | FAIL | NOT PROVIDED
+  CPU reference read:  PASS | SKIPPED
+  EGL import:          PASS | FAIL
+  OpenGL validation:   PASS | FAIL
+  CUDA registration:   PASS | FAIL | SKIPPED
+```
+
+Exit codes: `0` when the complete chain ran and passed, `1` when a stage
+failed, `2` when nothing failed but skipped stages keep the chain
+unvalidated (for example `--no-cuda` or a build without CUDA).
+
+The CUDA device is selected with `cuGLGetDevices()` so it matches the GPU
+behind the GL context (`--gpu`), not blindly device 0, and context handling
+uses the primary-context API, which keeps the same signature across CUDA
+11/12/13 (the unversioned `cuCtxCreate` does not).
 
 Build:
 
@@ -23,11 +50,18 @@ cc -O2 -Wall -DHAVE_CUDA -I ../../include/uapi -I/usr/include/libdrm \
   -ldrm -lgbm -lEGL -lGL -lcuda
 ```
 
+Options: `--device /dev/dri/cardN` (Hermes node), `--gpu /dev/dri/renderDN`
+(import GPU), `--wait-ms MS`, `--no-cuda`.
+
 ## pitch_detect.c
 
 Compares the GPU's view of an imported frame against the CPU view of the
 same DMA-BUF under several hypotheses (declared pitch, width*4, vertical
-flip, R/B swap, brute-forced pitch scan, drift-filtered rows).
+flip, R/B swap, brute-forced pitch scan, drift-filtered rows). Waits on the
+exported sync file and brackets both CPU snapshots with
+`DMA_BUF_IOCTL_SYNC` so the reference cannot be an in-flight frame.
+
+Options: `--device /dev/dri/cardN`, `--gpu /dev/dri/renderDN`.
 
 ## Known finding (2026-08, NVIDIA 595.84, RTX 5060 Ti)
 
@@ -38,3 +72,12 @@ the buffer; beyond that the GPU reads the wrong pages while the CPU view
 (`mmap`) of the very same DMA-BUF is pixel-perfect. Visible as diagonal
 stripe corruption at larger modes. The Hermes NVIDIA fork therefore uses a
 CPU-copy capture path for NVENC sessions until this is resolved.
+
+Related teardown finding: once CUDA/GL interop has touched the imported
+buffer in a process, the same driver segfaults when the last GPU-side
+reference to the import is released, regardless of teardown order
+(`eglDestroyImage`, texture delete or `eglTerminate`, whichever comes
+last). Without the CUDA stage the identical teardown runs clean. The
+checker therefore skips the GPU object teardown after CUDA interop and
+leaves the release to process cleanup via `_exit`, keeping its exit code
+deterministic.

--- a/tools/hermes-egl-import-check/README.md
+++ b/tools/hermes-egl-import-check/README.md
@@ -42,7 +42,14 @@ behind the GL context (`--gpu`), not blindly device 0, and context handling
 uses the primary-context API, which keeps the same signature across CUDA
 11/12/13 (the unversioned `cuCtxCreate` does not).
 
-Build:
+Build (from the repository root, together with the other tools):
+
+```bash
+make tools                # CUDA stage compiled out
+make tools HAVE_CUDA=1    # with the CUDA stage (needs cuda.h/cudaGL.h, libcuda)
+```
+
+Or standalone:
 
 ```bash
 cc -O2 -Wall -DHAVE_CUDA -I ../../include/uapi -I/usr/include/libdrm \

--- a/tools/hermes-egl-import-check/README.md
+++ b/tools/hermes-egl-import-check/README.md
@@ -1,0 +1,40 @@
+# hermes-egl-import-check / pitch_detect
+
+Diagnostic consumers for the NVENC/EGL side of the roadmap item
+"NVENC/AMF DMA-BUF import validation".
+
+## hermes_egl_import_check.c
+
+Validates the NVENC-style consumer chain for a live Hermes-KMS frame:
+
+```
+ACQUIRE_FRAME (DMA-BUF) -> eglCreateImage(EGL_LINUX_DMA_BUF_EXT)
+  -> texture bind (OES, falling back to glEGLImageTargetTexStorageEXT)
+  -> FBO readback (proves sampling)
+  -> GL blit into an own texture -> cuGraphicsGLRegisterImage
+     (mirrors the Sunshine/Hermes CUDA converter flow)
+```
+
+Build:
+
+```bash
+cc -O2 -Wall -DHAVE_CUDA -I ../../include/uapi -I/usr/include/libdrm \
+  -o hermes-egl-import-check hermes_egl_import_check.c \
+  -ldrm -lgbm -lEGL -lGL -lcuda
+```
+
+## pitch_detect.c
+
+Compares the GPU's view of an imported frame against the CPU view of the
+same DMA-BUF under several hypotheses (declared pitch, width*4, vertical
+flip, R/B swap, brute-forced pitch scan, drift-filtered rows).
+
+## Known finding (2026-08, NVIDIA 595.84, RTX 5060 Ti)
+
+The NVIDIA proprietary driver imports these system-memory DMA-BUFs via
+`EGL_EXT_image_dma_buf_import` (with the TexStorageEXT bind), but the
+sampled content is only correct for roughly the first contiguous ~2 MB of
+the buffer; beyond that the GPU reads the wrong pages while the CPU view
+(`mmap`) of the very same DMA-BUF is pixel-perfect. Visible as diagonal
+stripe corruption at larger modes. The Hermes NVIDIA fork therefore uses a
+CPU-copy capture path for NVENC sessions until this is resolved.

--- a/tools/hermes-egl-import-check/hermes_egl_import_check.c
+++ b/tools/hermes-egl-import-check/hermes_egl_import_check.c
@@ -1,0 +1,664 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// hermes-egl-import-check: validate the NVENC-style consumer path for
+// Hermes-KMS frames on NVIDIA (and any other EGL/GL/CUDA stack):
+//
+//   ACQUIRE_FRAME (DMA-BUF) -> eglCreateImage(EGL_LINUX_DMA_BUF_EXT)
+//     -> glEGLImageTargetTexture2DOES -> FBO readback (proves sampling)
+//     -> cuGraphicsGLRegisterImage (proves the Sunshine/Hermes CUDA interop)
+//
+// This is the exact frame path Hermes uses for NVENC: the encoder imports the
+// captured DMA-BUF through EGL on the render GPU and maps the GL texture into
+// CUDA. VAAPI has its own checker (hermes-kms-import-check); this tool covers
+// the NVIDIA side of the roadmap ("NVENC/AMF DMA-BUF import validation").
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <drm/drm_fourcc.h>
+#include <drm/hermes_kms_drm.h>
+
+#include <xf86drm.h>
+
+#include <gbm.h>
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#define GL_GLEXT_PROTOTYPES 1
+#include <GL/gl.h>
+#include <GL/glext.h>
+
+#ifdef HAVE_CUDA
+#include <cuda.h>
+#include <cudaGL.h>
+#endif
+
+#ifndef EGL_LINUX_DMA_BUF_EXT
+#define EGL_LINUX_DMA_BUF_EXT 0x3270
+#endif
+#ifndef EGL_LINUX_DRM_FOURCC_EXT
+#define EGL_LINUX_DRM_FOURCC_EXT 0x3271
+#endif
+#ifndef EGL_DMA_BUF_PLANE0_FD_EXT
+#define EGL_DMA_BUF_PLANE0_FD_EXT 0x3272
+#define EGL_DMA_BUF_PLANE0_OFFSET_EXT 0x3273
+#define EGL_DMA_BUF_PLANE0_PITCH_EXT 0x3274
+#endif
+#ifndef EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT
+#define EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT 0x3443
+#define EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT 0x3444
+#endif
+
+typedef void(GLAPIENTRY *PFNGLEGLIMAGETARGETTEXTURE2DOESPROC_local)(GLenum target, void *image);
+
+static void usage(const char *argv0)
+{
+	fprintf(stderr,
+		"Usage: %s [--device /dev/dri/cardN] [--gpu /dev/dri/renderDN] [--wait-ms MS] [--no-cuda]\n",
+		argv0);
+}
+
+static int open_if_hermes(const char *path)
+{
+	struct drm_hermes_kms_version version;
+	int fd;
+
+	fd = open(path, O_RDWR | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+
+	memset(&version, 0, sizeof(version));
+	if (ioctl(fd, DRM_IOCTL_HERMES_KMS_GET_VERSION, &version) == 0 &&
+	    strcmp(version.driver_name, "hermes-kms") == 0)
+		return fd;
+
+	close(fd);
+	return -1;
+}
+
+static int open_auto_hermes(void)
+{
+	struct dirent *entry;
+	DIR *dir;
+	int fd = -1;
+
+	dir = opendir("/dev/dri");
+	if (!dir)
+		return -1;
+
+	while ((entry = readdir(dir)) != NULL) {
+		char path[PATH_MAX];
+
+		if (strncmp(entry->d_name, "card", 4) != 0 &&
+		    strncmp(entry->d_name, "renderD", 7) != 0)
+			continue;
+
+		snprintf(path, sizeof(path), "/dev/dri/%s", entry->d_name);
+		fd = open_if_hermes(path);
+		if (fd >= 0)
+			break;
+	}
+
+	closedir(dir);
+	return fd;
+}
+
+// Open the first render node that is NOT the Hermes virtual device: that is
+// the real GPU which must import the frame (mirrors
+// display_hermes_vram_t::open_real_render_node in Hermes).
+static int open_real_gpu(const char *path, char *name_out, size_t name_len)
+{
+	struct dirent *entry;
+	DIR *dir;
+	int fd = -1;
+
+	if (path) {
+		fd = open(path, O_RDWR | O_CLOEXEC);
+	} else {
+		dir = opendir("/dev/dri");
+		if (!dir)
+			return -1;
+
+		while ((entry = readdir(dir)) != NULL) {
+			char candidate[PATH_MAX];
+
+			if (strncmp(entry->d_name, "renderD", 7) != 0)
+				continue;
+
+			snprintf(candidate, sizeof(candidate), "/dev/dri/%s", entry->d_name);
+			fd = open(candidate, O_RDWR | O_CLOEXEC);
+			if (fd < 0)
+				continue;
+
+			drmVersionPtr ver = drmGetVersion(fd);
+			bool is_hermes = ver && ver->name &&
+					 strcmp(ver->name, "hermes-kms") == 0;
+			if (ver)
+				drmFreeVersion(ver);
+			if (is_hermes) {
+				close(fd);
+				fd = -1;
+				continue;
+			}
+			break;
+		}
+		closedir(dir);
+	}
+
+	if (fd >= 0 && name_out) {
+		drmVersionPtr ver = drmGetVersion(fd);
+		if (ver && ver->name)
+			snprintf(name_out, name_len, "%s", ver->name);
+		else
+			snprintf(name_out, name_len, "unknown");
+		if (ver)
+			drmFreeVersion(ver);
+	}
+
+	return fd;
+}
+
+static int wait_for_frame(int fd, uint32_t wait_ms)
+{
+	struct drm_hermes_kms_status status;
+	struct drm_hermes_kms_wait_frame wait;
+
+	memset(&status, 0, sizeof(status));
+	if (ioctl(fd, DRM_IOCTL_HERMES_KMS_GET_STATUS, &status) < 0) {
+		perror("GET_STATUS");
+		return 1;
+	}
+
+	if (status.flags & HERMES_KMS_STATUS_FRAME_VALID)
+		return 0;
+
+	memset(&wait, 0, sizeof(wait));
+	wait.after_sequence = status.frame_sequence;
+	wait.timeout_ms = wait_ms;
+
+	if (ioctl(fd, DRM_IOCTL_HERMES_KMS_WAIT_FRAME, &wait) < 0) {
+		perror("WAIT_FRAME");
+		return 1;
+	}
+
+	if (!(wait.flags & HERMES_KMS_WAIT_FRAME_READY)) {
+		fprintf(stderr, "WAIT_FRAME returned without a ready frame\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+static int acquire_frame(int fd, struct drm_hermes_kms_acquire_frame *frame)
+{
+	memset(frame, 0, sizeof(*frame));
+	frame->flags = HERMES_KMS_FRAME_REQUEST_DMABUF |
+		       HERMES_KMS_FRAME_REQUEST_SYNC_FILE;
+
+	if (ioctl(fd, DRM_IOCTL_HERMES_KMS_ACQUIRE_FRAME, frame) < 0) {
+		perror("ACQUIRE_FRAME");
+		return 1;
+	}
+
+	if (!(frame->flags & HERMES_KMS_FRAME_DMABUF_VALID)) {
+		fprintf(stderr, "ACQUIRE_FRAME did not return DMA-BUF fds\n");
+		return 1;
+	}
+
+	if (!frame->plane_count || frame->plane_count > 4) {
+		fprintf(stderr, "invalid plane_count=%u\n", frame->plane_count);
+		return 1;
+	}
+
+	for (uint32_t i = 0; i < frame->plane_count; i++) {
+		if (frame->dma_buf_fd[i] < 0) {
+			fprintf(stderr, "plane %u has no DMA-BUF fd\n", i);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static void close_frame_fds(struct drm_hermes_kms_acquire_frame *frame)
+{
+	for (uint32_t i = 0; i < frame->plane_count && i < 4; i++) {
+		if (frame->dma_buf_fd[i] >= 0) {
+			close(frame->dma_buf_fd[i]);
+			frame->dma_buf_fd[i] = -1;
+		}
+	}
+	if (frame->sync_file_fd >= 0) {
+		close(frame->sync_file_fd);
+		frame->sync_file_fd = -1;
+	}
+}
+
+// CPU ground truth: mmap plane 0 and CRC a few rows so the GPU readback can be
+// compared against what is actually in the buffer.
+static uint32_t crc32_simple(const uint8_t *data, size_t len, uint32_t crc)
+{
+	crc = ~crc;
+	for (size_t i = 0; i < len; i++) {
+		crc ^= data[i];
+		for (int b = 0; b < 8; b++)
+			crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+	}
+	return ~crc;
+}
+
+static bool cpu_crc_rows(const struct drm_hermes_kms_acquire_frame *frame,
+			 uint32_t rows, uint32_t *crc_out)
+{
+	size_t map_len = (size_t) frame->pitch[0] * frame->height + frame->offset[0];
+	void *map = mmap(NULL, map_len, PROT_READ, MAP_SHARED, frame->dma_buf_fd[0], 0);
+
+	if (map == MAP_FAILED)
+		return false;
+
+	uint32_t crc = 0;
+	const uint8_t *base = (const uint8_t *) map + frame->offset[0];
+	uint32_t row_bytes = frame->width * 4;
+
+	for (uint32_t y = 0; y < rows && y < frame->height; y++)
+		crc = crc32_simple(base + (size_t) y * frame->pitch[0], row_bytes, crc);
+
+	munmap(map, map_len);
+	*crc_out = crc;
+	return true;
+}
+
+int main(int argc, char **argv)
+{
+	const char *hermes_path = NULL;
+	const char *gpu_path = NULL;
+	uint32_t wait_ms = 2000;
+	bool do_cuda = true;
+	int ret = 1;
+
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--device") == 0 && i + 1 < argc) {
+			hermes_path = argv[++i];
+		} else if (strcmp(argv[i], "--gpu") == 0 && i + 1 < argc) {
+			gpu_path = argv[++i];
+		} else if (strcmp(argv[i], "--wait-ms") == 0 && i + 1 < argc) {
+			wait_ms = (uint32_t) strtoul(argv[++i], NULL, 0);
+		} else if (strcmp(argv[i], "--no-cuda") == 0) {
+			do_cuda = false;
+		} else {
+			usage(argv[0]);
+			return 1;
+		}
+	}
+
+	// --- 1. Acquire a frame from Hermes-KMS ---------------------------------
+	int hermes_fd = hermes_path ? open_if_hermes(hermes_path) : open_auto_hermes();
+	if (hermes_fd < 0) {
+		fprintf(stderr, "FAIL: no Hermes-KMS device found (module loaded? output enabled?)\n");
+		return 1;
+	}
+
+	if (wait_for_frame(hermes_fd, wait_ms)) {
+		fprintf(stderr, "FAIL: no scanout frame (compositor not driving HERMES output?)\n");
+		close(hermes_fd);
+		return 1;
+	}
+
+	struct drm_hermes_kms_acquire_frame frame;
+	if (acquire_frame(hermes_fd, &frame)) {
+		close(hermes_fd);
+		return 1;
+	}
+
+	printf("frame: %ux%u format=0x%08x ('%c%c%c%c') modifier=0x%016llx planes=%u pitch0=%u\n",
+	       frame.width, frame.height, frame.format,
+	       frame.format & 0xff, (frame.format >> 8) & 0xff,
+	       (frame.format >> 16) & 0xff, (frame.format >> 24) & 0xff,
+	       (unsigned long long) frame.modifier, frame.plane_count, frame.pitch[0]);
+
+	uint32_t cpu_crc = 0;
+	bool have_cpu_crc = cpu_crc_rows(&frame, 8, &cpu_crc);
+	if (have_cpu_crc)
+		printf("PASS: CPU mmap of plane 0 (crc32 of first 8 rows: 0x%08x)\n", cpu_crc);
+	else
+		printf("INFO: CPU mmap not supported by exporter (non-fatal)\n");
+
+	// --- 2. EGL display/context on the real GPU ----------------------------
+	char gpu_name[64] = {0};
+	int gpu_fd = open_real_gpu(gpu_path, gpu_name, sizeof(gpu_name));
+	if (gpu_fd < 0) {
+		fprintf(stderr, "FAIL: no real render GPU found\n");
+		goto out_frame;
+	}
+	printf("render GPU: %s\n", gpu_name);
+
+	struct gbm_device *gbm = gbm_create_device(gpu_fd);
+	if (!gbm) {
+		fprintf(stderr, "FAIL: gbm_create_device\n");
+		goto out_frame;
+	}
+
+	PFNEGLGETPLATFORMDISPLAYEXTPROC get_platform_display =
+		(PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress("eglGetPlatformDisplayEXT");
+	if (!get_platform_display) {
+		fprintf(stderr, "FAIL: eglGetPlatformDisplayEXT unavailable\n");
+		goto out_frame;
+	}
+
+	EGLDisplay dpy = get_platform_display(EGL_PLATFORM_GBM_KHR, gbm, NULL);
+	if (dpy == EGL_NO_DISPLAY) {
+		fprintf(stderr, "FAIL: eglGetPlatformDisplay(GBM)\n");
+		goto out_frame;
+	}
+
+	EGLint major, minor;
+	if (!eglInitialize(dpy, &major, &minor)) {
+		fprintf(stderr, "FAIL: eglInitialize (0x%x)\n", eglGetError());
+		goto out_frame;
+	}
+	printf("EGL %d.%d on %s / %s\n", major, minor,
+	       eglQueryString(dpy, EGL_VENDOR), eglQueryString(dpy, EGL_VERSION));
+
+	const char *exts = eglQueryString(dpy, EGL_EXTENSIONS);
+	bool has_import = exts && strstr(exts, "EGL_EXT_image_dma_buf_import");
+	bool has_modifiers = exts && strstr(exts, "EGL_EXT_image_dma_buf_import_modifiers");
+	printf("%s: EGL_EXT_image_dma_buf_import\n", has_import ? "PASS" : "FAIL");
+	printf("INFO: EGL_EXT_image_dma_buf_import_modifiers %s\n",
+	       has_modifiers ? "present" : "absent");
+	if (!has_import)
+		goto out_egl;
+
+	if (!eglBindAPI(EGL_OPENGL_API)) {
+		fprintf(stderr, "FAIL: eglBindAPI(OPENGL)\n");
+		goto out_egl;
+	}
+
+	EGLContext ctx = eglCreateContext(dpy, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, NULL);
+	if (ctx == EGL_NO_CONTEXT) {
+		fprintf(stderr, "FAIL: eglCreateContext (0x%x)\n", eglGetError());
+		goto out_egl;
+	}
+
+	if (!eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx)) {
+		fprintf(stderr, "FAIL: eglMakeCurrent surfaceless (0x%x)\n", eglGetError());
+		goto out_egl;
+	}
+	printf("GL renderer: %s\n", (const char *) glGetString(GL_RENDERER));
+
+	// --- 3. Import the DMA-BUF as an EGLImage ------------------------------
+	EGLAttrib attribs[64];
+	int a = 0;
+	attribs[a++] = EGL_WIDTH;
+	attribs[a++] = frame.width;
+	attribs[a++] = EGL_HEIGHT;
+	attribs[a++] = frame.height;
+	attribs[a++] = EGL_LINUX_DRM_FOURCC_EXT;
+	attribs[a++] = frame.format;
+	attribs[a++] = EGL_DMA_BUF_PLANE0_FD_EXT;
+	attribs[a++] = frame.dma_buf_fd[0];
+	attribs[a++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+	attribs[a++] = frame.offset[0];
+	attribs[a++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+	attribs[a++] = frame.pitch[0];
+	if (frame.modifier != DRM_FORMAT_MOD_INVALID) {
+		attribs[a++] = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+		attribs[a++] = (EGLAttrib) (frame.modifier & 0xFFFFFFFFu);
+		attribs[a++] = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+		attribs[a++] = (EGLAttrib) (frame.modifier >> 32);
+	}
+	attribs[a++] = EGL_NONE;
+
+	EGLImage image = eglCreateImage(dpy, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
+					NULL, attribs);
+	if (image == EGL_NO_IMAGE) {
+		fprintf(stderr, "FAIL: eglCreateImage(EGL_LINUX_DMA_BUF_EXT) error=0x%x\n",
+			eglGetError());
+		fprintf(stderr, "      -> this GPU/driver refuses to import the Hermes DMA-BUF\n");
+		goto out_egl;
+	}
+	printf("PASS: eglCreateImage imported the Hermes DMA-BUF\n");
+
+	// --- 4. Bind to a texture and read back through the GPU ----------------
+	PFNGLEGLIMAGETARGETTEXTURE2DOESPROC_local image_target_texture =
+		(PFNGLEGLIMAGETARGETTEXTURE2DOESPROC_local)
+			eglGetProcAddress("glEGLImageTargetTexture2DOES");
+	if (!image_target_texture) {
+		fprintf(stderr, "FAIL: glEGLImageTargetTexture2DOES unavailable\n");
+		goto out_egl;
+	}
+
+	GLuint tex = 0;
+	glGenTextures(1, &tex);
+	glBindTexture(GL_TEXTURE_2D, tex);
+	image_target_texture(GL_TEXTURE_2D, image);
+	GLenum err = glGetError();
+	if (err != GL_NO_ERROR) {
+		printf("INFO: glEGLImageTargetTexture2DOES(GL_TEXTURE_2D) error=0x%x, "
+		       "trying glEGLImageTargetTexStorageEXT\n", err);
+
+		// Desktop-GL drivers (NVIDIA in particular) often reject the
+		// GLES-style OES bind for foreign DMA-BUF images but accept the
+		// immutable-storage path from GL_EXT_EGL_image_storage.
+		typedef void(GLAPIENTRY * PFNGLEGLIMAGETARGETTEXSTORAGEEXTPROC_local)(
+			GLenum target, void *image, const GLint *attrib_list);
+		PFNGLEGLIMAGETARGETTEXSTORAGEEXTPROC_local image_target_storage =
+			(PFNGLEGLIMAGETARGETTEXSTORAGEEXTPROC_local)
+				eglGetProcAddress("glEGLImageTargetTexStorageEXT");
+		if (!image_target_storage) {
+			fprintf(stderr, "FAIL: glEGLImageTargetTexStorageEXT unavailable too\n");
+			goto out_egl;
+		}
+
+		glDeleteTextures(1, &tex);
+		glGenTextures(1, &tex);
+		glBindTexture(GL_TEXTURE_2D, tex);
+		image_target_storage(GL_TEXTURE_2D, image, NULL);
+		err = glGetError();
+		if (err != GL_NO_ERROR) {
+			fprintf(stderr, "FAIL: glEGLImageTargetTexStorageEXT error=0x%x\n", err);
+			goto out_egl;
+		}
+		printf("PASS: EGLImage bound as GL texture (TexStorageEXT path)\n");
+	} else {
+		printf("PASS: EGLImage bound as GL texture (OES path)\n");
+	}
+
+	GLuint fbo = 0;
+	glGenFramebuffers(1, &fbo);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+			       GL_TEXTURE_2D, tex, 0);
+	if (glCheckFramebufferStatus(GL_READ_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+		fprintf(stderr, "FAIL: FBO incomplete with imported texture\n");
+		goto out_egl;
+	}
+
+	uint32_t rows = frame.height < 8 ? frame.height : 8;
+	uint8_t *pixels = calloc((size_t) frame.width * rows, 4);
+	if (!pixels)
+		goto out_egl;
+
+	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	glReadPixels(0, 0, frame.width, rows, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
+	err = glGetError();
+	if (err != GL_NO_ERROR) {
+		fprintf(stderr, "FAIL: glReadPixels from imported texture error=0x%x\n", err);
+		free(pixels);
+		goto out_egl;
+	}
+
+	uint32_t gpu_crc = 0;
+	for (uint32_t y = 0; y < rows; y++)
+		gpu_crc = crc32_simple(pixels + (size_t) y * frame.width * 4,
+				       frame.width * 4, gpu_crc);
+	free(pixels);
+
+	printf("PASS: GPU readback of imported frame (crc32 of first %u rows: 0x%08x)\n",
+	       rows, gpu_crc);
+	if (have_cpu_crc) {
+		if (gpu_crc == cpu_crc)
+			printf("PASS: GPU readback matches CPU ground truth\n");
+		else
+			printf("WARN: GPU/CPU crc mismatch (0x%08x vs 0x%08x) — row order or "
+			       "cache coherency; inspect before trusting zero-copy\n",
+			       gpu_crc, cpu_crc);
+	}
+
+	// --- 5. Emulate the real encoder pipeline --------------------------------
+	// Hermes/Sunshine never hands the *imported* texture to CUDA. The GL
+	// converter (egl::sws_t) samples it into textures Sunshine allocated
+	// itself, and only those are registered with CUDA. Reproduce that:
+	// blit imported -> own texture, then map the own texture into CUDA.
+	GLuint conv = 0;
+	glGenTextures(1, &conv);
+	glBindTexture(GL_TEXTURE_2D, conv);
+	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, frame.width, frame.height);
+	err = glGetError();
+	if (err != GL_NO_ERROR) {
+		fprintf(stderr, "FAIL: allocating conversion texture error=0x%x\n", err);
+		goto out_egl;
+	}
+
+	GLuint draw_fbo = 0;
+	glGenFramebuffers(1, &draw_fbo);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, draw_fbo);
+	glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+			       GL_TEXTURE_2D, conv, 0);
+	if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+		fprintf(stderr, "FAIL: draw FBO incomplete\n");
+		goto out_egl;
+	}
+
+	// read FBO still holds the imported texture
+	glBlitFramebuffer(0, 0, frame.width, frame.height,
+			  0, 0, frame.width, frame.height,
+			  GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	glFinish();
+	err = glGetError();
+	if (err != GL_NO_ERROR) {
+		fprintf(stderr, "FAIL: GL blit imported->own texture error=0x%x\n", err);
+		goto out_egl;
+	}
+	printf("PASS: GL converter pass (imported -> own texture)\n");
+
+#ifdef HAVE_CUDA
+	if (do_cuda) {
+		CUresult cr = cuInit(0);
+		if (cr != CUDA_SUCCESS) {
+			printf("INFO: cuInit failed (%d) — skipping CUDA stage\n", (int) cr);
+			goto cuda_done;
+		}
+
+		CUdevice dev;
+		CUcontext cuctx;
+		if (cuDeviceGet(&dev, 0) != CUDA_SUCCESS ||
+		    cuCtxCreate(&cuctx, NULL, 0, dev) != CUDA_SUCCESS) {
+			fprintf(stderr, "FAIL: CUDA context creation\n");
+			goto out_egl;
+		}
+
+		CUgraphicsResource res;
+		cr = cuGraphicsGLRegisterImage(&res, conv, GL_TEXTURE_2D,
+					       CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY);
+		if (cr != CUDA_SUCCESS) {
+			const char *es = NULL;
+			cuGetErrorString(cr, &es);
+			fprintf(stderr, "FAIL: cuGraphicsGLRegisterImage(own texture): %s\n",
+				es ? es : "?");
+			cuCtxDestroy(cuctx);
+			goto out_egl;
+		}
+
+		CUarray arr;
+		if (cuGraphicsMapResources(1, &res, 0) != CUDA_SUCCESS ||
+		    cuGraphicsSubResourceGetMappedArray(&arr, res, 0, 0) != CUDA_SUCCESS) {
+			fprintf(stderr, "FAIL: mapping GL texture into CUDA\n");
+			cuGraphicsUnregisterResource(res);
+			cuCtxDestroy(cuctx);
+			goto out_egl;
+		}
+
+		// Pull the first row through CUDA and CRC it against the same row
+		// read back through GL: both must see identical bytes of the same
+		// frozen copy (the blit decoupled it from the live desktop).
+		uint32_t row_bytes = frame.width * 4;
+		uint8_t *cuda_row = malloc(row_bytes);
+		uint8_t *gl_row = malloc(row_bytes);
+		if (!cuda_row || !gl_row) {
+			free(cuda_row);
+			free(gl_row);
+			cuGraphicsUnmapResources(1, &res, 0);
+			cuGraphicsUnregisterResource(res);
+			cuCtxDestroy(cuctx);
+			goto out_egl;
+		}
+
+		CUDA_MEMCPY2D cp;
+		memset(&cp, 0, sizeof(cp));
+		cp.srcMemoryType = CU_MEMORYTYPE_ARRAY;
+		cp.srcArray = arr;
+		cp.dstMemoryType = CU_MEMORYTYPE_HOST;
+		cp.dstHost = cuda_row;
+		cp.dstPitch = row_bytes;
+		cp.WidthInBytes = row_bytes;
+		cp.Height = 1;
+		if (cuMemcpy2D(&cp) != CUDA_SUCCESS) {
+			fprintf(stderr, "FAIL: cuMemcpy2D from mapped array\n");
+			free(cuda_row);
+			free(gl_row);
+			cuGraphicsUnmapResources(1, &res, 0);
+			cuGraphicsUnregisterResource(res);
+			cuCtxDestroy(cuctx);
+			goto out_egl;
+		}
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, draw_fbo);
+		glReadPixels(0, 0, frame.width, 1, GL_RGBA, GL_UNSIGNED_BYTE, gl_row);
+
+		uint32_t cuda_crc = crc32_simple(cuda_row, row_bytes, 0);
+		uint32_t glrow_crc = crc32_simple(gl_row, row_bytes, 0);
+		free(cuda_row);
+		free(gl_row);
+
+		cuGraphicsUnmapResources(1, &res, 0);
+		cuGraphicsUnregisterResource(res);
+		cuCtxDestroy(cuctx);
+
+		printf("PASS: CUDA mapped the converter output (GL interop)\n");
+		if (cuda_crc == glrow_crc)
+			printf("PASS: CUDA row matches GL row (crc32 0x%08x) — data is intact\n",
+			       cuda_crc);
+		else
+			printf("WARN: CUDA/GL row crc mismatch (0x%08x vs 0x%08x)\n",
+			       cuda_crc, glrow_crc);
+	}
+cuda_done:
+#else
+	(void) do_cuda;
+	printf("INFO: built without CUDA support (make HAVE_CUDA=1)\n");
+#endif
+
+	printf("\nRESULT: NVENC-style import chain OK "
+	       "(DMA-BUF -> EGL -> GL converter -> CUDA)\n");
+	ret = 0;
+
+out_egl:
+	// Unbind before teardown: terminating the display while a context is
+	// still current crashes some drivers during process exit.
+	eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	eglTerminate(dpy);
+out_frame:
+	close_frame_fds(&frame);
+	close(hermes_fd);
+	return ret;
+}

--- a/tools/hermes-egl-import-check/hermes_egl_import_check.c
+++ b/tools/hermes-egl-import-check/hermes_egl_import_check.c
@@ -3,7 +3,8 @@
 // hermes-egl-import-check: validate the NVENC-style consumer path for
 // Hermes-KMS frames on NVIDIA (and any other EGL/GL/CUDA stack):
 //
-//   ACQUIRE_FRAME (DMA-BUF) -> eglCreateImage(EGL_LINUX_DMA_BUF_EXT)
+//   ACQUIRE_FRAME (DMA-BUF) -> wait on the exported sync file
+//     -> eglCreateImage(EGL_LINUX_DMA_BUF_EXT)
 //     -> glEGLImageTargetTexture2DOES -> FBO readback (proves sampling)
 //     -> cuGraphicsGLRegisterImage (proves the Sunshine/Hermes CUDA interop)
 //
@@ -11,11 +12,16 @@
 // captured DMA-BUF through EGL on the render GPU and maps the GL texture into
 // CUDA. VAAPI has its own checker (hermes-kms-import-check); this tool covers
 // the NVIDIA side of the roadmap ("NVENC/AMF DMA-BUF import validation").
+//
+// Every stage reports PASS / FAIL / SKIPPED / NOT PROVIDED individually and
+// the final RESULT only claims a complete chain when every required stage
+// actually ran and passed.
 
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <poll.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -24,6 +30,8 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <unistd.h>
+
+#include <linux/dma-buf.h>
 
 #include <drm/drm_fourcc.h>
 #include <drm/hermes_kms_drm.h>
@@ -61,10 +69,45 @@
 
 typedef void(GLAPIENTRY *PFNGLEGLIMAGETARGETTEXTURE2DOESPROC_local)(GLenum target, void *image);
 
+enum stage_result {
+	ST_NOT_RUN = 0,
+	ST_PASS,
+	ST_FAIL,
+	ST_SKIPPED,
+	ST_NOT_PROVIDED,
+};
+
+static const char *stage_name(enum stage_result s)
+{
+	switch (s) {
+	case ST_PASS:
+		return "PASS";
+	case ST_FAIL:
+		return "FAIL";
+	case ST_SKIPPED:
+		return "SKIPPED";
+	case ST_NOT_PROVIDED:
+		return "NOT PROVIDED";
+	default:
+		return "not run";
+	}
+}
+
+struct stage_results {
+	enum stage_result acquire;
+	enum stage_result fence;
+	enum stage_result cpu_ref;
+	enum stage_result egl_import;
+	enum stage_result gl_validate;
+	enum stage_result cuda_reg;
+};
+
 static void usage(const char *argv0)
 {
 	fprintf(stderr,
-		"Usage: %s [--device /dev/dri/cardN] [--gpu /dev/dri/renderDN] [--wait-ms MS] [--no-cuda]\n",
+		"Usage: %s [--device /dev/dri/cardN] [--gpu /dev/dri/renderDN] [--wait-ms MS] [--no-cuda]\n"
+		"Exit codes: 0 = complete chain passed, 1 = a stage failed,\n"
+		"            2 = no failures but the chain is incomplete (stages skipped)\n",
 		argv0);
 }
 
@@ -244,6 +287,37 @@ static void close_frame_fds(struct drm_hermes_kms_acquire_frame *frame)
 	}
 }
 
+// ACQUIRE_FRAME only guarantees that the frame was exported, not that the
+// producer finished writing it. The driver exports the framebuffer's write
+// fence as a sync file; wait for it before using the pixels as a reference.
+static enum stage_result wait_frame_fence(const struct drm_hermes_kms_acquire_frame *frame,
+					  int timeout_ms)
+{
+	struct pollfd pfd;
+	int rv;
+
+	if (!(frame->flags & HERMES_KMS_FRAME_SYNC_FILE_VALID) ||
+	    frame->sync_file_fd < 0) {
+		printf("INFO: driver provided no sync file for this frame\n");
+		return ST_NOT_PROVIDED;
+	}
+
+	pfd.fd = frame->sync_file_fd;
+	pfd.events = POLLIN;
+	pfd.revents = 0;
+	do {
+		rv = poll(&pfd, 1, timeout_ms);
+	} while (rv < 0 && errno == EINTR);
+
+	if (rv <= 0) {
+		fprintf(stderr, "FAIL: frame fence did not signal within %d ms\n", timeout_ms);
+		return ST_FAIL;
+	}
+
+	printf("PASS: frame fence signalled (producer finished writing)\n");
+	return ST_PASS;
+}
+
 // CPU ground truth: mmap plane 0 and CRC a few rows so the GPU readback can be
 // compared against what is actually in the buffer.
 static uint32_t crc32_simple(const uint8_t *data, size_t len, uint32_t crc)
@@ -266,12 +340,23 @@ static bool cpu_crc_rows(const struct drm_hermes_kms_acquire_frame *frame,
 	if (map == MAP_FAILED)
 		return false;
 
+	// CPU access to a DMA-BUF mapping must be bracketed with the sync
+	// ioctl; this read is the reference every later stage is compared
+	// against, so an unsynchronized read here would poison all verdicts.
+	struct dma_buf_sync sync;
+	memset(&sync, 0, sizeof(sync));
+	sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ;
+	ioctl(frame->dma_buf_fd[0], DMA_BUF_IOCTL_SYNC, &sync);
+
 	uint32_t crc = 0;
 	const uint8_t *base = (const uint8_t *) map + frame->offset[0];
 	uint32_t row_bytes = frame->width * 4;
 
 	for (uint32_t y = 0; y < rows && y < frame->height; y++)
 		crc = crc32_simple(base + (size_t) y * frame->pitch[0], row_bytes, crc);
+
+	sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+	ioctl(frame->dma_buf_fd[0], DMA_BUF_IOCTL_SYNC, &sync);
 
 	munmap(map, map_len);
 	*crc_out = crc;
@@ -285,6 +370,27 @@ int main(int argc, char **argv)
 	uint32_t wait_ms = 2000;
 	bool do_cuda = true;
 	int ret = 1;
+
+	struct stage_results st;
+	memset(&st, 0, sizeof(st));
+
+	int hermes_fd = -1;
+	int gpu_fd = -1;
+	struct gbm_device *gbm = NULL;
+	EGLDisplay dpy = EGL_NO_DISPLAY;
+	EGLContext ctx = EGL_NO_CONTEXT;
+	EGLImage image = EGL_NO_IMAGE;
+	GLuint tex = 0, fbo = 0, conv = 0, draw_fbo = 0;
+	bool egl_initialized = false;
+#ifdef HAVE_CUDA
+	CUdevice cuda_dev = 0;
+	bool cuda_ctx_retained = false;
+	bool cuda_interop_ran = false;
+#endif
+
+	struct drm_hermes_kms_acquire_frame frame;
+	memset(&frame, 0, sizeof(frame));
+	frame.sync_file_fd = -1;
 
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--device") == 0 && i + 1 < argc) {
@@ -302,23 +408,24 @@ int main(int argc, char **argv)
 	}
 
 	// --- 1. Acquire a frame from Hermes-KMS ---------------------------------
-	int hermes_fd = hermes_path ? open_if_hermes(hermes_path) : open_auto_hermes();
+	hermes_fd = hermes_path ? open_if_hermes(hermes_path) : open_auto_hermes();
 	if (hermes_fd < 0) {
 		fprintf(stderr, "FAIL: no Hermes-KMS device found (module loaded? output enabled?)\n");
-		return 1;
+		st.acquire = ST_FAIL;
+		goto out;
 	}
 
 	if (wait_for_frame(hermes_fd, wait_ms)) {
 		fprintf(stderr, "FAIL: no scanout frame (compositor not driving HERMES output?)\n");
-		close(hermes_fd);
-		return 1;
+		st.acquire = ST_FAIL;
+		goto out;
 	}
 
-	struct drm_hermes_kms_acquire_frame frame;
 	if (acquire_frame(hermes_fd, &frame)) {
-		close(hermes_fd);
-		return 1;
+		st.acquire = ST_FAIL;
+		goto out;
 	}
+	st.acquire = ST_PASS;
 
 	printf("frame: %ux%u format=0x%08x ('%c%c%c%c') modifier=0x%016llx planes=%u pitch0=%u\n",
 	       frame.width, frame.height, frame.format,
@@ -326,46 +433,60 @@ int main(int argc, char **argv)
 	       (frame.format >> 16) & 0xff, (frame.format >> 24) & 0xff,
 	       (unsigned long long) frame.modifier, frame.plane_count, frame.pitch[0]);
 
+	// --- 2. Wait for the producer's write fence -----------------------------
+	st.fence = wait_frame_fence(&frame, (int) wait_ms);
+	if (st.fence == ST_FAIL)
+		goto out;
+
 	uint32_t cpu_crc = 0;
 	bool have_cpu_crc = cpu_crc_rows(&frame, 8, &cpu_crc);
-	if (have_cpu_crc)
+	if (have_cpu_crc) {
 		printf("PASS: CPU mmap of plane 0 (crc32 of first 8 rows: 0x%08x)\n", cpu_crc);
-	else
-		printf("INFO: CPU mmap not supported by exporter (non-fatal)\n");
+		st.cpu_ref = ST_PASS;
+	} else {
+		printf("INFO: CPU mmap not supported by exporter, no CPU reference available\n");
+		st.cpu_ref = ST_SKIPPED;
+	}
 
-	// --- 2. EGL display/context on the real GPU ----------------------------
+	// --- 3. EGL display/context on the real GPU ----------------------------
 	char gpu_name[64] = {0};
-	int gpu_fd = open_real_gpu(gpu_path, gpu_name, sizeof(gpu_name));
+	gpu_fd = open_real_gpu(gpu_path, gpu_name, sizeof(gpu_name));
 	if (gpu_fd < 0) {
 		fprintf(stderr, "FAIL: no real render GPU found\n");
-		goto out_frame;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 	printf("render GPU: %s\n", gpu_name);
 
-	struct gbm_device *gbm = gbm_create_device(gpu_fd);
+	gbm = gbm_create_device(gpu_fd);
 	if (!gbm) {
 		fprintf(stderr, "FAIL: gbm_create_device\n");
-		goto out_frame;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 
 	PFNEGLGETPLATFORMDISPLAYEXTPROC get_platform_display =
 		(PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress("eglGetPlatformDisplayEXT");
 	if (!get_platform_display) {
 		fprintf(stderr, "FAIL: eglGetPlatformDisplayEXT unavailable\n");
-		goto out_frame;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 
-	EGLDisplay dpy = get_platform_display(EGL_PLATFORM_GBM_KHR, gbm, NULL);
+	dpy = get_platform_display(EGL_PLATFORM_GBM_KHR, gbm, NULL);
 	if (dpy == EGL_NO_DISPLAY) {
 		fprintf(stderr, "FAIL: eglGetPlatformDisplay(GBM)\n");
-		goto out_frame;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 
 	EGLint major, minor;
 	if (!eglInitialize(dpy, &major, &minor)) {
 		fprintf(stderr, "FAIL: eglInitialize (0x%x)\n", eglGetError());
-		goto out_frame;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
+	egl_initialized = true;
 	printf("EGL %d.%d on %s / %s\n", major, minor,
 	       eglQueryString(dpy, EGL_VENDOR), eglQueryString(dpy, EGL_VERSION));
 
@@ -375,27 +496,32 @@ int main(int argc, char **argv)
 	printf("%s: EGL_EXT_image_dma_buf_import\n", has_import ? "PASS" : "FAIL");
 	printf("INFO: EGL_EXT_image_dma_buf_import_modifiers %s\n",
 	       has_modifiers ? "present" : "absent");
-	if (!has_import)
-		goto out_egl;
+	if (!has_import) {
+		st.egl_import = ST_FAIL;
+		goto out;
+	}
 
 	if (!eglBindAPI(EGL_OPENGL_API)) {
 		fprintf(stderr, "FAIL: eglBindAPI(OPENGL)\n");
-		goto out_egl;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 
-	EGLContext ctx = eglCreateContext(dpy, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, NULL);
+	ctx = eglCreateContext(dpy, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, NULL);
 	if (ctx == EGL_NO_CONTEXT) {
 		fprintf(stderr, "FAIL: eglCreateContext (0x%x)\n", eglGetError());
-		goto out_egl;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 
 	if (!eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx)) {
 		fprintf(stderr, "FAIL: eglMakeCurrent surfaceless (0x%x)\n", eglGetError());
-		goto out_egl;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 	printf("GL renderer: %s\n", (const char *) glGetString(GL_RENDERER));
 
-	// --- 3. Import the DMA-BUF as an EGLImage ------------------------------
+	// --- 4. Import the DMA-BUF as an EGLImage ------------------------------
 	EGLAttrib attribs[64];
 	int a = 0;
 	attribs[a++] = EGL_WIDTH;
@@ -410,7 +536,10 @@ int main(int argc, char **argv)
 	attribs[a++] = frame.offset[0];
 	attribs[a++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
 	attribs[a++] = frame.pitch[0];
-	if (frame.modifier != DRM_FORMAT_MOD_INVALID) {
+	// Only pass modifier attributes when the driver reported a valid
+	// modifier AND the EGL implementation advertises the modifier
+	// extension; otherwise omit them entirely.
+	if (frame.modifier != DRM_FORMAT_MOD_INVALID && has_modifiers) {
 		attribs[a++] = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
 		attribs[a++] = (EGLAttrib) (frame.modifier & 0xFFFFFFFFu);
 		attribs[a++] = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
@@ -418,26 +547,28 @@ int main(int argc, char **argv)
 	}
 	attribs[a++] = EGL_NONE;
 
-	EGLImage image = eglCreateImage(dpy, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
-					NULL, attribs);
+	image = eglCreateImage(dpy, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
+			       NULL, attribs);
 	if (image == EGL_NO_IMAGE) {
 		fprintf(stderr, "FAIL: eglCreateImage(EGL_LINUX_DMA_BUF_EXT) error=0x%x\n",
 			eglGetError());
 		fprintf(stderr, "      -> this GPU/driver refuses to import the Hermes DMA-BUF\n");
-		goto out_egl;
+		st.egl_import = ST_FAIL;
+		goto out;
 	}
 	printf("PASS: eglCreateImage imported the Hermes DMA-BUF\n");
+	st.egl_import = ST_PASS;
 
-	// --- 4. Bind to a texture and read back through the GPU ----------------
+	// --- 5. Bind to a texture and read back through the GPU ----------------
 	PFNGLEGLIMAGETARGETTEXTURE2DOESPROC_local image_target_texture =
 		(PFNGLEGLIMAGETARGETTEXTURE2DOESPROC_local)
 			eglGetProcAddress("glEGLImageTargetTexture2DOES");
 	if (!image_target_texture) {
 		fprintf(stderr, "FAIL: glEGLImageTargetTexture2DOES unavailable\n");
-		goto out_egl;
+		st.gl_validate = ST_FAIL;
+		goto out;
 	}
 
-	GLuint tex = 0;
 	glGenTextures(1, &tex);
 	glBindTexture(GL_TEXTURE_2D, tex);
 	image_target_texture(GL_TEXTURE_2D, image);
@@ -456,7 +587,8 @@ int main(int argc, char **argv)
 				eglGetProcAddress("glEGLImageTargetTexStorageEXT");
 		if (!image_target_storage) {
 			fprintf(stderr, "FAIL: glEGLImageTargetTexStorageEXT unavailable too\n");
-			goto out_egl;
+			st.gl_validate = ST_FAIL;
+			goto out;
 		}
 
 		glDeleteTextures(1, &tex);
@@ -466,27 +598,31 @@ int main(int argc, char **argv)
 		err = glGetError();
 		if (err != GL_NO_ERROR) {
 			fprintf(stderr, "FAIL: glEGLImageTargetTexStorageEXT error=0x%x\n", err);
-			goto out_egl;
+			st.gl_validate = ST_FAIL;
+			goto out;
 		}
 		printf("PASS: EGLImage bound as GL texture (TexStorageEXT path)\n");
 	} else {
 		printf("PASS: EGLImage bound as GL texture (OES path)\n");
 	}
 
-	GLuint fbo = 0;
 	glGenFramebuffers(1, &fbo);
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
 	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
 			       GL_TEXTURE_2D, tex, 0);
 	if (glCheckFramebufferStatus(GL_READ_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
 		fprintf(stderr, "FAIL: FBO incomplete with imported texture\n");
-		goto out_egl;
+		st.gl_validate = ST_FAIL;
+		goto out;
 	}
 
 	uint32_t rows = frame.height < 8 ? frame.height : 8;
 	uint8_t *pixels = calloc((size_t) frame.width * rows, 4);
-	if (!pixels)
-		goto out_egl;
+	if (!pixels) {
+		fprintf(stderr, "FAIL: out of memory for readback buffer\n");
+		st.gl_validate = ST_FAIL;
+		goto out;
+	}
 
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
 	glReadPixels(0, 0, frame.width, rows, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
@@ -494,7 +630,8 @@ int main(int argc, char **argv)
 	if (err != GL_NO_ERROR) {
 		fprintf(stderr, "FAIL: glReadPixels from imported texture error=0x%x\n", err);
 		free(pixels);
-		goto out_egl;
+		st.gl_validate = ST_FAIL;
+		goto out;
 	}
 
 	uint32_t gpu_crc = 0;
@@ -509,34 +646,35 @@ int main(int argc, char **argv)
 		if (gpu_crc == cpu_crc)
 			printf("PASS: GPU readback matches CPU ground truth\n");
 		else
-			printf("WARN: GPU/CPU crc mismatch (0x%08x vs 0x%08x) — row order or "
-			       "cache coherency; inspect before trusting zero-copy\n",
+			printf("WARN: GPU/CPU crc mismatch (0x%08x vs 0x%08x); the compositor may "
+			       "have redrawn the live buffer between the reads, use pitch_detect "
+			       "for a drift-filtered verdict\n",
 			       gpu_crc, cpu_crc);
 	}
 
-	// --- 5. Emulate the real encoder pipeline --------------------------------
+	// --- 6. Emulate the real encoder pipeline --------------------------------
 	// Hermes/Sunshine never hands the *imported* texture to CUDA. The GL
 	// converter (egl::sws_t) samples it into textures Sunshine allocated
 	// itself, and only those are registered with CUDA. Reproduce that:
 	// blit imported -> own texture, then map the own texture into CUDA.
-	GLuint conv = 0;
 	glGenTextures(1, &conv);
 	glBindTexture(GL_TEXTURE_2D, conv);
 	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, frame.width, frame.height);
 	err = glGetError();
 	if (err != GL_NO_ERROR) {
 		fprintf(stderr, "FAIL: allocating conversion texture error=0x%x\n", err);
-		goto out_egl;
+		st.gl_validate = ST_FAIL;
+		goto out;
 	}
 
-	GLuint draw_fbo = 0;
 	glGenFramebuffers(1, &draw_fbo);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, draw_fbo);
 	glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
 			       GL_TEXTURE_2D, conv, 0);
 	if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
 		fprintf(stderr, "FAIL: draw FBO incomplete\n");
-		goto out_egl;
+		st.gl_validate = ST_FAIL;
+		goto out;
 	}
 
 	// read FBO still holds the imported texture
@@ -547,27 +685,62 @@ int main(int argc, char **argv)
 	err = glGetError();
 	if (err != GL_NO_ERROR) {
 		fprintf(stderr, "FAIL: GL blit imported->own texture error=0x%x\n", err);
-		goto out_egl;
+		st.gl_validate = ST_FAIL;
+		goto out;
 	}
 	printf("PASS: GL converter pass (imported -> own texture)\n");
+	st.gl_validate = ST_PASS;
 
 #ifdef HAVE_CUDA
-	if (do_cuda) {
+	if (!do_cuda) {
+		printf("INFO: CUDA stage skipped (--no-cuda)\n");
+		st.cuda_reg = ST_SKIPPED;
+	} else {
 		CUresult cr = cuInit(0);
 		if (cr != CUDA_SUCCESS) {
-			printf("INFO: cuInit failed (%d) — skipping CUDA stage\n", (int) cr);
+			printf("INFO: cuInit failed (%d), CUDA stage skipped\n", (int) cr);
+			st.cuda_reg = ST_SKIPPED;
 			goto cuda_done;
 		}
 
-		CUdevice dev;
+		// Match the CUDA device to the GL context created on the
+		// selected render node; device 0 may be a different GPU on
+		// multi-GPU hosts and a register failure there would say
+		// nothing about Hermes-KMS interop.
+		unsigned int dev_count = 0;
+		cr = cuGLGetDevices(&dev_count, &cuda_dev, 1, CU_GL_DEVICE_LIST_ALL);
+		if (cr != CUDA_SUCCESS || dev_count == 0) {
+			printf("INFO: no CUDA device backs the current GL context (%d), "
+			       "CUDA stage skipped\n", (int) cr);
+			st.cuda_reg = ST_SKIPPED;
+			goto cuda_done;
+		}
+
+		char dev_name[128] = {0};
+		if (cuDeviceGetName(dev_name, sizeof(dev_name) - 1, cuda_dev) == CUDA_SUCCESS)
+			printf("CUDA device (via cuGLGetDevices): %s\n", dev_name);
+
+		// The primary-context API is signature-stable across CUDA
+		// 11/12/13; the unversioned cuCtxCreate is not (CUDA 13 added
+		// a params argument). The context is released at the very end
+		// of main: releasing it while the EGL context still exists
+		// tears down shared GL-interop driver state underneath it and
+		// crashes at least the NVIDIA driver during EGL/GL teardown.
 		CUcontext cuctx;
-		if (cuDeviceGet(&dev, 0) != CUDA_SUCCESS ||
-		    cuCtxCreate(&cuctx, NULL, 0, dev) != CUDA_SUCCESS) {
-			fprintf(stderr, "FAIL: CUDA context creation\n");
-			goto out_egl;
+		if (cuDevicePrimaryCtxRetain(&cuctx, cuda_dev) != CUDA_SUCCESS) {
+			fprintf(stderr, "FAIL: cuDevicePrimaryCtxRetain\n");
+			st.cuda_reg = ST_FAIL;
+			goto out;
+		}
+		cuda_ctx_retained = true;
+		if (cuCtxSetCurrent(cuctx) != CUDA_SUCCESS) {
+			fprintf(stderr, "FAIL: cuCtxSetCurrent\n");
+			st.cuda_reg = ST_FAIL;
+			goto out;
 		}
 
 		CUgraphicsResource res;
+		cuda_interop_ran = true;
 		cr = cuGraphicsGLRegisterImage(&res, conv, GL_TEXTURE_2D,
 					       CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY);
 		if (cr != CUDA_SUCCESS) {
@@ -575,8 +748,8 @@ int main(int argc, char **argv)
 			cuGetErrorString(cr, &es);
 			fprintf(stderr, "FAIL: cuGraphicsGLRegisterImage(own texture): %s\n",
 				es ? es : "?");
-			cuCtxDestroy(cuctx);
-			goto out_egl;
+			st.cuda_reg = ST_FAIL;
+			goto out;
 		}
 
 		CUarray arr;
@@ -584,23 +757,25 @@ int main(int argc, char **argv)
 		    cuGraphicsSubResourceGetMappedArray(&arr, res, 0, 0) != CUDA_SUCCESS) {
 			fprintf(stderr, "FAIL: mapping GL texture into CUDA\n");
 			cuGraphicsUnregisterResource(res);
-			cuCtxDestroy(cuctx);
-			goto out_egl;
+			st.cuda_reg = ST_FAIL;
+			goto out;
 		}
 
-		// Pull the first row through CUDA and CRC it against the same row
-		// read back through GL: both must see identical bytes of the same
-		// frozen copy (the blit decoupled it from the live desktop).
+		// Pull the first row through CUDA and CRC it against the same
+		// row read back through GL: both must see identical bytes of
+		// the same frozen copy (the blit decoupled it from the live
+		// desktop).
 		uint32_t row_bytes = frame.width * 4;
 		uint8_t *cuda_row = malloc(row_bytes);
 		uint8_t *gl_row = malloc(row_bytes);
 		if (!cuda_row || !gl_row) {
+			fprintf(stderr, "FAIL: out of memory for row buffers\n");
 			free(cuda_row);
 			free(gl_row);
 			cuGraphicsUnmapResources(1, &res, 0);
 			cuGraphicsUnregisterResource(res);
-			cuCtxDestroy(cuctx);
-			goto out_egl;
+			st.cuda_reg = ST_FAIL;
+			goto out;
 		}
 
 		CUDA_MEMCPY2D cp;
@@ -618,8 +793,8 @@ int main(int argc, char **argv)
 			free(gl_row);
 			cuGraphicsUnmapResources(1, &res, 0);
 			cuGraphicsUnregisterResource(res);
-			cuCtxDestroy(cuctx);
-			goto out_egl;
+			st.cuda_reg = ST_FAIL;
+			goto out;
 		}
 
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, draw_fbo);
@@ -632,33 +807,113 @@ int main(int argc, char **argv)
 
 		cuGraphicsUnmapResources(1, &res, 0);
 		cuGraphicsUnregisterResource(res);
-		cuCtxDestroy(cuctx);
 
 		printf("PASS: CUDA mapped the converter output (GL interop)\n");
+		st.cuda_reg = ST_PASS;
 		if (cuda_crc == glrow_crc)
-			printf("PASS: CUDA row matches GL row (crc32 0x%08x) — data is intact\n",
+			printf("PASS: CUDA row matches GL row (crc32 0x%08x), data is intact\n",
 			       cuda_crc);
 		else
 			printf("WARN: CUDA/GL row crc mismatch (0x%08x vs 0x%08x)\n",
 			       cuda_crc, glrow_crc);
 	}
-cuda_done:
+cuda_done:;
 #else
 	(void) do_cuda;
-	printf("INFO: built without CUDA support (make HAVE_CUDA=1)\n");
+	printf("INFO: built without CUDA support (make HAVE_CUDA=1), CUDA stage skipped\n");
+	st.cuda_reg = ST_SKIPPED;
 #endif
 
-	printf("\nRESULT: NVENC-style import chain OK "
-	       "(DMA-BUF -> EGL -> GL converter -> CUDA)\n");
-	ret = 0;
+out:
+	// The verdict must never be lost to a driver teardown quirk: print and
+	// flush it before any EGL/GL/CUDA cleanup runs.
+	printf("\nstage summary:\n");
+	printf("  frame acquisition:   %s\n", stage_name(st.acquire));
+	printf("  fence wait:          %s\n", stage_name(st.fence));
+	printf("  CPU reference read:  %s\n", stage_name(st.cpu_ref));
+	printf("  EGL import:          %s\n", stage_name(st.egl_import));
+	printf("  OpenGL validation:   %s\n", stage_name(st.gl_validate));
+	printf("  CUDA registration:   %s\n", stage_name(st.cuda_reg));
 
-out_egl:
+	bool any_fail = st.acquire == ST_FAIL || st.fence == ST_FAIL ||
+			st.cpu_ref == ST_FAIL || st.egl_import == ST_FAIL ||
+			st.gl_validate == ST_FAIL || st.cuda_reg == ST_FAIL;
+	bool complete = st.acquire == ST_PASS &&
+			(st.fence == ST_PASS || st.fence == ST_NOT_PROVIDED) &&
+			st.cpu_ref == ST_PASS &&
+			st.egl_import == ST_PASS &&
+			st.gl_validate == ST_PASS &&
+			st.cuda_reg == ST_PASS;
+
+	if (any_fail) {
+		printf("RESULT: FAIL, the chain is broken at the first failed stage above\n");
+		ret = 1;
+	} else if (complete) {
+		printf("RESULT: PASS, complete NVENC-style import chain "
+		       "(DMA-BUF -> EGL -> GL converter -> CUDA)\n");
+		ret = 0;
+	} else {
+		printf("RESULT: INCOMPLETE, no failures but skipped stages keep the "
+		       "chain unvalidated\n");
+		ret = 2;
+	}
+	fflush(stdout);
+
+#ifdef HAVE_CUDA
+	// NVIDIA (observed on 595.xx) segfaults inside the driver when the last
+	// GPU-side reference to an imported system-memory DMA-BUF is released
+	// after CUDA/GL interop touched it in the same process: whichever of
+	// eglDestroyImage, the texture delete or eglTerminate happens to drop
+	// that reference last crashes, in every ordering. Without the CUDA
+	// stage the full teardown below runs clean on the same driver. Close
+	// the kernel-side fds ourselves and leave the GPU object teardown to
+	// process cleanup, via _exit so driver atexit handlers cannot crash
+	// either. This keeps the exit code deterministic, which matters more
+	// for a diagnostic tool than freeing GPU handles a millisecond before
+	// the process ends.
+	if (cuda_interop_ran) {
+		fprintf(stderr, "INFO: skipping GPU object teardown after CUDA interop "
+				"(NVIDIA driver workaround)\n");
+		close_frame_fds(&frame);
+		if (hermes_fd >= 0)
+			close(hermes_fd);
+		_exit(ret);
+	}
+#endif
+
 	// Unbind before teardown: terminating the display while a context is
 	// still current crashes some drivers during process exit.
-	eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-	eglTerminate(dpy);
-out_frame:
+	if (egl_initialized) {
+		if (image != EGL_NO_IMAGE)
+			eglDestroyImage(dpy, image);
+		if (draw_fbo || fbo) {
+			GLuint fbos[2] = {fbo, draw_fbo};
+			glDeleteFramebuffers(2, fbos);
+		}
+		if (tex || conv) {
+			GLuint texs[2] = {tex, conv};
+			glDeleteTextures(2, texs);
+		}
+		eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+		if (ctx != EGL_NO_CONTEXT)
+			eglDestroyContext(dpy, ctx);
+		eglTerminate(dpy);
+	}
+	if (gbm)
+		gbm_device_destroy(gbm);
+	if (gpu_fd >= 0)
+		close(gpu_fd);
 	close_frame_fds(&frame);
-	close(hermes_fd);
+	if (hermes_fd >= 0)
+		close(hermes_fd);
+#ifdef HAVE_CUDA
+	// Released only now, after the EGL/GL teardown: see the retain comment
+	// in the CUDA stage.
+	if (cuda_ctx_retained) {
+		cuCtxSetCurrent(NULL);
+		cuDevicePrimaryCtxRelease(cuda_dev);
+	}
+#endif
+
 	return ret;
 }

--- a/tools/hermes-egl-import-check/pitch_detect.c
+++ b/tools/hermes-egl-import-check/pitch_detect.c
@@ -3,7 +3,9 @@
 // DMA-BUF: the declared one (frame.pitch[0]) or a wrongly assumed width*4.
 // Compares GPU-read rows against CPU ground truth under both hypotheses.
 
+#include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,6 +17,8 @@
 #include <limits.h>
 #include <stdbool.h>
 
+#include <linux/dma-buf.h>
+
 #include <drm/drm_fourcc.h>
 #include <drm/hermes_kms_drm.h>
 #include <xf86drm.h>
@@ -24,6 +28,13 @@
 #define GL_GLEXT_PROTOTYPES 1
 #include <GL/gl.h>
 #include <GL/glext.h>
+
+static void usage(const char *argv0)
+{
+	fprintf(stderr,
+		"Usage: %s [--device /dev/dri/cardN] [--gpu /dev/dri/renderDN]\n",
+		argv0);
+}
 
 static int open_if_hermes(const char *path)
 {
@@ -39,73 +50,44 @@ static int open_if_hermes(const char *path)
 	return -1;
 }
 
-int main(void)
+static int open_auto_hermes(void)
 {
-	setvbuf(stdout, NULL, _IONBF, 0);
-
-	int hermes_fd = -1;
-	DIR *dir = opendir("/dev/dri");
 	struct dirent *entry;
+	DIR *dir = opendir("/dev/dri");
+	int fd = -1;
+
 	while (dir && (entry = readdir(dir))) {
 		char path[PATH_MAX];
 		if (strncmp(entry->d_name, "card", 4) && strncmp(entry->d_name, "renderD", 7))
 			continue;
 		snprintf(path, sizeof(path), "/dev/dri/%s", entry->d_name);
-		hermes_fd = open_if_hermes(path);
-		if (hermes_fd >= 0)
+		fd = open_if_hermes(path);
+		if (fd >= 0)
 			break;
 	}
 	if (dir)
 		closedir(dir);
-	if (hermes_fd < 0) {
-		fprintf(stderr, "no hermes device\n");
-		return 1;
-	}
+	return fd;
+}
 
-	struct drm_hermes_kms_status status;
-	memset(&status, 0, sizeof(status));
-	ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_GET_STATUS, &status);
-	if (!(status.flags & HERMES_KMS_STATUS_FRAME_VALID)) {
-		struct drm_hermes_kms_wait_frame wait;
-		memset(&wait, 0, sizeof(wait));
-		wait.after_sequence = status.frame_sequence;
-		wait.timeout_ms = 10000;
-		ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_WAIT_FRAME, &wait);
-	}
+// Open the render GPU that should import the frame: an explicit path when
+// given, otherwise the first render node that is not the Hermes device.
+static int open_real_gpu(const char *path)
+{
+	struct dirent *entry;
+	DIR *dir;
+	int fd = -1;
 
-	struct drm_hermes_kms_acquire_frame frame;
-	memset(&frame, 0, sizeof(frame));
-	frame.flags = HERMES_KMS_FRAME_REQUEST_DMABUF;
-	if (ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_ACQUIRE_FRAME, &frame) < 0 ||
-	    !(frame.flags & HERMES_KMS_FRAME_DMABUF_VALID)) {
-		fprintf(stderr, "acquire failed\n");
-		return 1;
-	}
+	if (path)
+		return open(path, O_RDWR | O_CLOEXEC);
 
-	const uint32_t W = frame.width, H = frame.height;
-	const uint32_t declared_pitch = frame.pitch[0];
-	const uint32_t tight_pitch = W * 4;
-	printf("frame %ux%u declared_pitch=%u tight_pitch=%u\n", W, H, declared_pitch, tight_pitch);
-
-	// CPU snapshot FIRST (freeze our reference before any GPU work)
-	size_t map_len = (size_t) declared_pitch * H + frame.offset[0];
-	uint8_t *cpu = mmap(NULL, map_len, PROT_READ, MAP_SHARED, frame.dma_buf_fd[0], 0);
-	if (cpu == MAP_FAILED) {
-		fprintf(stderr, "mmap failed\n");
-		return 1;
-	}
-	uint8_t *snap = malloc(map_len);
-	memcpy(snap, cpu, map_len);
-
-	// GPU import
-	int gpu_fd = -1;
 	dir = opendir("/dev/dri");
 	while (dir && (entry = readdir(dir))) {
+		char candidate[PATH_MAX];
 		if (strncmp(entry->d_name, "renderD", 7))
 			continue;
-		char path[PATH_MAX];
-		snprintf(path, sizeof(path), "/dev/dri/%s", entry->d_name);
-		int fd = open(path, O_RDWR | O_CLOEXEC);
+		snprintf(candidate, sizeof(candidate), "/dev/dri/%s", entry->d_name);
+		fd = open(candidate, O_RDWR | O_CLOEXEC);
 		if (fd < 0)
 			continue;
 		drmVersionPtr ver = drmGetVersion(fd);
@@ -114,49 +96,233 @@ int main(void)
 			drmFreeVersion(ver);
 		if (herm) {
 			close(fd);
+			fd = -1;
 			continue;
 		}
-		gpu_fd = fd;
 		break;
 	}
 	if (dir)
 		closedir(dir);
+	return fd;
+}
 
-	struct gbm_device *gbm = gbm_create_device(gpu_fd);
-	PFNEGLGETPLATFORMDISPLAYEXTPROC gpd =
-		(PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress("eglGetPlatformDisplayEXT");
-	EGLDisplay dpy = gpd(EGL_PLATFORM_GBM_KHR, gbm, NULL);
-	eglInitialize(dpy, NULL, NULL);
-	eglBindAPI(EGL_OPENGL_API);
-	EGLContext ctx = eglCreateContext(dpy, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, NULL);
-	eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx);
+static void close_frame_fds(struct drm_hermes_kms_acquire_frame *frame)
+{
+	for (uint32_t i = 0; i < frame->plane_count && i < 4; i++) {
+		if (frame->dma_buf_fd[i] >= 0) {
+			close(frame->dma_buf_fd[i]);
+			frame->dma_buf_fd[i] = -1;
+		}
+	}
+	if (frame->sync_file_fd >= 0) {
+		close(frame->sync_file_fd);
+		frame->sync_file_fd = -1;
+	}
+}
 
-	EGLAttrib attribs[] = {
-		EGL_WIDTH, W,
-		EGL_HEIGHT, H,
-		EGL_LINUX_DRM_FOURCC_EXT, frame.format,
-		EGL_DMA_BUF_PLANE0_FD_EXT, frame.dma_buf_fd[0],
-		EGL_DMA_BUF_PLANE0_OFFSET_EXT, frame.offset[0],
-		EGL_DMA_BUF_PLANE0_PITCH_EXT, declared_pitch,
-		EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, (EGLAttrib) (frame.modifier & 0xFFFFFFFFu),
-		EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, (EGLAttrib) (frame.modifier >> 32),
-		EGL_NONE
-	};
-	EGLImage image = eglCreateImage(dpy, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
-	if (image == EGL_NO_IMAGE) {
-		fprintf(stderr, "import failed 0x%x\n", eglGetError());
-		return 1;
+// The CPU snapshots below are the reference for every verdict; bracket them
+// with the DMA-BUF sync ioctl as the mmap contract requires.
+static void cpu_read_locked(int dmabuf_fd, uint8_t *dst, const uint8_t *src, size_t len)
+{
+	struct dma_buf_sync sync;
+
+	memset(&sync, 0, sizeof(sync));
+	sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ;
+	ioctl(dmabuf_fd, DMA_BUF_IOCTL_SYNC, &sync);
+
+	memcpy(dst, src, len);
+
+	sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+	ioctl(dmabuf_fd, DMA_BUF_IOCTL_SYNC, &sync);
+}
+
+int main(int argc, char **argv)
+{
+	const char *hermes_path = NULL;
+	const char *gpu_path = NULL;
+	int ret = 1;
+
+	int hermes_fd = -1;
+	int gpu_fd = -1;
+	struct gbm_device *gbm = NULL;
+	EGLDisplay dpy = EGL_NO_DISPLAY;
+	EGLContext ctx = EGL_NO_CONTEXT;
+	EGLImage image = EGL_NO_IMAGE;
+	GLuint tex = 0, fbo = 0;
+	bool egl_initialized = false;
+	uint8_t *cpu = MAP_FAILED;
+	uint8_t *snap = NULL, *gpu_rows = NULL, *gpu_all = NULL;
+	size_t map_len = 0;
+
+	struct drm_hermes_kms_acquire_frame frame;
+	memset(&frame, 0, sizeof(frame));
+	frame.sync_file_fd = -1;
+
+	setvbuf(stdout, NULL, _IONBF, 0);
+
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--device") == 0 && i + 1 < argc) {
+			hermes_path = argv[++i];
+		} else if (strcmp(argv[i], "--gpu") == 0 && i + 1 < argc) {
+			gpu_path = argv[++i];
+		} else {
+			usage(argv[0]);
+			return 1;
+		}
 	}
 
-	typedef void(GLAPIENTRY * TexStorageFn)(GLenum, void *, const GLint *);
-	TexStorageFn tex_storage = (TexStorageFn) eglGetProcAddress("glEGLImageTargetTexStorageEXT");
-	GLuint tex;
+	hermes_fd = hermes_path ? open_if_hermes(hermes_path) : open_auto_hermes();
+	if (hermes_fd < 0) {
+		fprintf(stderr, "no hermes device\n");
+		goto out;
+	}
+
+	struct drm_hermes_kms_status status;
+	memset(&status, 0, sizeof(status));
+	if (ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_GET_STATUS, &status) < 0) {
+		perror("GET_STATUS");
+		goto out;
+	}
+	if (!(status.flags & HERMES_KMS_STATUS_FRAME_VALID)) {
+		struct drm_hermes_kms_wait_frame wait;
+		memset(&wait, 0, sizeof(wait));
+		wait.after_sequence = status.frame_sequence;
+		wait.timeout_ms = 10000;
+		if (ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_WAIT_FRAME, &wait) < 0 ||
+		    !(wait.flags & HERMES_KMS_WAIT_FRAME_READY)) {
+			fprintf(stderr, "no scanout frame within 10s\n");
+			goto out;
+		}
+	}
+
+	frame.flags = HERMES_KMS_FRAME_REQUEST_DMABUF |
+		      HERMES_KMS_FRAME_REQUEST_SYNC_FILE;
+	if (ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_ACQUIRE_FRAME, &frame) < 0 ||
+	    !(frame.flags & HERMES_KMS_FRAME_DMABUF_VALID) ||
+	    !frame.plane_count || frame.dma_buf_fd[0] < 0) {
+		fprintf(stderr, "acquire failed\n");
+		goto out;
+	}
+
+	// ACQUIRE_FRAME does not guarantee the producer finished writing; wait
+	// for the exported write fence before freezing the CPU reference.
+	if ((frame.flags & HERMES_KMS_FRAME_SYNC_FILE_VALID) && frame.sync_file_fd >= 0) {
+		struct pollfd pfd = {.fd = frame.sync_file_fd, .events = POLLIN};
+		int rv;
+		do {
+			rv = poll(&pfd, 1, 2000);
+		} while (rv < 0 && errno == EINTR);
+		if (rv <= 0) {
+			fprintf(stderr, "frame fence did not signal within 2s\n");
+			goto out;
+		}
+	}
+
+	const uint32_t W = frame.width, H = frame.height;
+	const uint32_t declared_pitch = frame.pitch[0];
+	const uint32_t tight_pitch = W * 4;
+	if (!W || !H || declared_pitch < tight_pitch) {
+		fprintf(stderr, "implausible frame geometry %ux%u pitch=%u\n",
+			W, H, declared_pitch);
+		goto out;
+	}
+	printf("frame %ux%u declared_pitch=%u tight_pitch=%u\n", W, H, declared_pitch, tight_pitch);
+
+	// CPU snapshot FIRST (freeze our reference before any GPU work)
+	map_len = (size_t) declared_pitch * H + frame.offset[0];
+	cpu = mmap(NULL, map_len, PROT_READ, MAP_SHARED, frame.dma_buf_fd[0], 0);
+	if (cpu == MAP_FAILED) {
+		fprintf(stderr, "mmap failed\n");
+		goto out;
+	}
+	snap = malloc(map_len);
+	if (!snap) {
+		fprintf(stderr, "out of memory\n");
+		goto out;
+	}
+	cpu_read_locked(frame.dma_buf_fd[0], snap, cpu, map_len);
+
+	// GPU import
+	gpu_fd = open_real_gpu(gpu_path);
+	if (gpu_fd < 0) {
+		fprintf(stderr, "no render GPU found\n");
+		goto out;
+	}
+
+	gbm = gbm_create_device(gpu_fd);
+	if (!gbm) {
+		fprintf(stderr, "gbm_create_device failed\n");
+		goto out;
+	}
+	PFNEGLGETPLATFORMDISPLAYEXTPROC gpd =
+		(PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress("eglGetPlatformDisplayEXT");
+	if (!gpd) {
+		fprintf(stderr, "eglGetPlatformDisplayEXT unavailable\n");
+		goto out;
+	}
+	dpy = gpd(EGL_PLATFORM_GBM_KHR, gbm, NULL);
+	if (dpy == EGL_NO_DISPLAY || !eglInitialize(dpy, NULL, NULL)) {
+		fprintf(stderr, "EGL display init failed\n");
+		dpy = EGL_NO_DISPLAY;
+		goto out;
+	}
+	egl_initialized = true;
+	if (!eglBindAPI(EGL_OPENGL_API)) {
+		fprintf(stderr, "eglBindAPI failed\n");
+		goto out;
+	}
+	ctx = eglCreateContext(dpy, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, NULL);
+	if (ctx == EGL_NO_CONTEXT || !eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx)) {
+		fprintf(stderr, "EGL context setup failed (0x%x)\n", eglGetError());
+		goto out;
+	}
+
+	const char *exts = eglQueryString(dpy, EGL_EXTENSIONS);
+	bool has_modifiers = exts && strstr(exts, "EGL_EXT_image_dma_buf_import_modifiers");
+
+	EGLAttrib attribs[32];
+	int a = 0;
+	attribs[a++] = EGL_WIDTH;
+	attribs[a++] = W;
+	attribs[a++] = EGL_HEIGHT;
+	attribs[a++] = H;
+	attribs[a++] = EGL_LINUX_DRM_FOURCC_EXT;
+	attribs[a++] = frame.format;
+	attribs[a++] = EGL_DMA_BUF_PLANE0_FD_EXT;
+	attribs[a++] = frame.dma_buf_fd[0];
+	attribs[a++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+	attribs[a++] = frame.offset[0];
+	attribs[a++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+	attribs[a++] = declared_pitch;
+	// Omit the modifier attributes when the driver reported none or the
+	// EGL implementation does not advertise the modifier extension.
+	if (frame.modifier != DRM_FORMAT_MOD_INVALID && has_modifiers) {
+		attribs[a++] = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+		attribs[a++] = (EGLAttrib) (frame.modifier & 0xFFFFFFFFu);
+		attribs[a++] = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+		attribs[a++] = (EGLAttrib) (frame.modifier >> 32);
+	}
+	attribs[a++] = EGL_NONE;
+
+	image = eglCreateImage(dpy, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
+	if (image == EGL_NO_IMAGE) {
+		fprintf(stderr, "import failed 0x%x\n", eglGetError());
+		goto out;
+	}
+
 	glGenTextures(1, &tex);
 	glBindTexture(GL_TEXTURE_2D, tex);
 	while (glGetError()) {}
 	glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
 	const char *bind_path = "OES";
 	if (glGetError() != GL_NO_ERROR) {
+		typedef void(GLAPIENTRY * TexStorageFn)(GLenum, void *, const GLint *);
+		TexStorageFn tex_storage =
+			(TexStorageFn) eglGetProcAddress("glEGLImageTargetTexStorageEXT");
+		if (!tex_storage) {
+			fprintf(stderr, "OES bind failed and glEGLImageTargetTexStorageEXT unavailable\n");
+			goto out;
+		}
 		glDeleteTextures(1, &tex);
 		glGenTextures(1, &tex);
 		glBindTexture(GL_TEXTURE_2D, tex);
@@ -164,17 +330,24 @@ int main(void)
 		bind_path = "TexStorageEXT";
 		if (glGetError() != GL_NO_ERROR) {
 			fprintf(stderr, "both binds failed\n");
-			return 1;
+			goto out;
 		}
 	}
 	printf("bind path: %s\n", bind_path);
 
-	GLuint fbo;
 	glGenFramebuffers(1, &fbo);
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
 	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
+	if (glCheckFramebufferStatus(GL_READ_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+		fprintf(stderr, "FBO incomplete with imported texture\n");
+		goto out;
+	}
 
-	uint8_t *gpu_rows = malloc((size_t) W * 4 * 32);
+	gpu_rows = malloc((size_t) W * 4 * 32);
+	if (!gpu_rows) {
+		fprintf(stderr, "out of memory\n");
+		goto out;
+	}
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
 	glReadPixels(0, 0, W, 32, GL_BGRA, GL_UNSIGNED_BYTE, gpu_rows);
 	glFinish();
@@ -183,7 +356,11 @@ int main(void)
 	// the GPU readback, so compare byte-match FRACTIONS: a pitch shear
 	// misaligns everything, animation only touches small regions.
 	const uint32_t rows_to_check = H < 200 ? H : 200;
-	uint8_t *gpu_all = malloc((size_t) W * 4 * rows_to_check);
+	gpu_all = malloc((size_t) W * 4 * rows_to_check);
+	if (!gpu_all) {
+		fprintf(stderr, "out of memory\n");
+		goto out;
+	}
 	glReadPixels(0, 0, W, rows_to_check, GL_BGRA, GL_UNSIGNED_BYTE, gpu_all);
 	glFinish();
 
@@ -227,10 +404,16 @@ int main(void)
 		const uint32_t y0 = H > 600 ? 400 : H / 4;
 		const uint32_t nrows = 200;
 		uint8_t *gpu_mid = malloc((size_t) W * 4 * nrows);
+		uint8_t *post = malloc(map_len);
+		if (!gpu_mid || !post) {
+			fprintf(stderr, "out of memory\n");
+			free(gpu_mid);
+			free(post);
+			goto out;
+		}
 		glReadPixels(0, y0, W, nrows, GL_BGRA, GL_UNSIGNED_BYTE, gpu_mid);
 		glFinish();
-		uint8_t *post = malloc(map_len);
-		memcpy(post, cpu, map_len);
+		cpu_read_locked(frame.dma_buf_fd[0], post, cpu, map_len);
 
 		uint32_t stable = 0, st_decl = 0, st_tight = 0, st_other = 0;
 		for (uint32_t r = 0; r < nrows && y0 + r < H; r++) {
@@ -263,6 +446,10 @@ int main(void)
 		const uint32_t y0 = H > 600 ? 500 : H / 2;
 		const uint32_t nrows = 24;
 		uint8_t *mid = malloc((size_t) W * 4 * nrows);
+		if (!mid) {
+			fprintf(stderr, "out of memory\n");
+			goto out;
+		}
 		glReadPixels(0, y0, W, nrows, GL_BGRA, GL_UNSIGNED_BYTE, mid);
 		glFinish();
 
@@ -306,18 +493,42 @@ int main(void)
 	printf("\ngpu row0[0..15]: ");
 	for (int i = 0; i < 16; i++)
 		printf("%02x ", gpu_all[i]);
-	printf("\ncpu row100[0..15]: ");
-	for (int i = 0; i < 16; i++)
-		printf("%02x ", snap[frame.offset[0] + (size_t) 100 * declared_pitch + i]);
-	printf("\ngpu row100[0..15]: ");
-	for (int i = 0; i < 16; i++)
-		printf("%02x ", gpu_all[(size_t) 100 * W * 4 + i]);
+	if (H > 100 && rows_to_check > 100) {
+		printf("\ncpu row100[0..15]: ");
+		for (int i = 0; i < 16; i++)
+			printf("%02x ", snap[frame.offset[0] + (size_t) 100 * declared_pitch + i]);
+		printf("\ngpu row100[0..15]: ");
+		for (int i = 0; i < 16; i++)
+			printf("%02x ", gpu_all[(size_t) 100 * W * 4 + i]);
+	}
 	printf("\n");
-	free(gpu_all);
 
+	ret = 0;
+
+out:
+	free(gpu_all);
 	free(gpu_rows);
 	free(snap);
-	munmap(cpu, map_len);
-	eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-	return 0;
+	if (cpu != MAP_FAILED && map_len)
+		munmap(cpu, map_len);
+	if (egl_initialized) {
+		if (fbo)
+			glDeleteFramebuffers(1, &fbo);
+		if (tex)
+			glDeleteTextures(1, &tex);
+		if (image != EGL_NO_IMAGE)
+			eglDestroyImage(dpy, image);
+		eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+		if (ctx != EGL_NO_CONTEXT)
+			eglDestroyContext(dpy, ctx);
+		eglTerminate(dpy);
+	}
+	if (gbm)
+		gbm_device_destroy(gbm);
+	if (gpu_fd >= 0)
+		close(gpu_fd);
+	close_frame_fds(&frame);
+	if (hermes_fd >= 0)
+		close(hermes_fd);
+	return ret;
 }

--- a/tools/hermes-egl-import-check/pitch_detect.c
+++ b/tools/hermes-egl-import-check/pitch_detect.c
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: GPL-2.0
+// Detect which row pitch the GPU actually used when importing a Hermes-KMS
+// DMA-BUF: the declared one (frame.pitch[0]) or a wrongly assumed width*4.
+// Compares GPU-read rows against CPU ground truth under both hypotheses.
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <limits.h>
+#include <stdbool.h>
+
+#include <drm/drm_fourcc.h>
+#include <drm/hermes_kms_drm.h>
+#include <xf86drm.h>
+#include <gbm.h>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#define GL_GLEXT_PROTOTYPES 1
+#include <GL/gl.h>
+#include <GL/glext.h>
+
+static int open_if_hermes(const char *path)
+{
+	struct drm_hermes_kms_version version;
+	int fd = open(path, O_RDWR | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+	memset(&version, 0, sizeof(version));
+	if (ioctl(fd, DRM_IOCTL_HERMES_KMS_GET_VERSION, &version) == 0 &&
+	    strcmp(version.driver_name, "hermes-kms") == 0)
+		return fd;
+	close(fd);
+	return -1;
+}
+
+int main(void)
+{
+	setvbuf(stdout, NULL, _IONBF, 0);
+
+	int hermes_fd = -1;
+	DIR *dir = opendir("/dev/dri");
+	struct dirent *entry;
+	while (dir && (entry = readdir(dir))) {
+		char path[PATH_MAX];
+		if (strncmp(entry->d_name, "card", 4) && strncmp(entry->d_name, "renderD", 7))
+			continue;
+		snprintf(path, sizeof(path), "/dev/dri/%s", entry->d_name);
+		hermes_fd = open_if_hermes(path);
+		if (hermes_fd >= 0)
+			break;
+	}
+	if (dir)
+		closedir(dir);
+	if (hermes_fd < 0) {
+		fprintf(stderr, "no hermes device\n");
+		return 1;
+	}
+
+	struct drm_hermes_kms_status status;
+	memset(&status, 0, sizeof(status));
+	ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_GET_STATUS, &status);
+	if (!(status.flags & HERMES_KMS_STATUS_FRAME_VALID)) {
+		struct drm_hermes_kms_wait_frame wait;
+		memset(&wait, 0, sizeof(wait));
+		wait.after_sequence = status.frame_sequence;
+		wait.timeout_ms = 10000;
+		ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_WAIT_FRAME, &wait);
+	}
+
+	struct drm_hermes_kms_acquire_frame frame;
+	memset(&frame, 0, sizeof(frame));
+	frame.flags = HERMES_KMS_FRAME_REQUEST_DMABUF;
+	if (ioctl(hermes_fd, DRM_IOCTL_HERMES_KMS_ACQUIRE_FRAME, &frame) < 0 ||
+	    !(frame.flags & HERMES_KMS_FRAME_DMABUF_VALID)) {
+		fprintf(stderr, "acquire failed\n");
+		return 1;
+	}
+
+	const uint32_t W = frame.width, H = frame.height;
+	const uint32_t declared_pitch = frame.pitch[0];
+	const uint32_t tight_pitch = W * 4;
+	printf("frame %ux%u declared_pitch=%u tight_pitch=%u\n", W, H, declared_pitch, tight_pitch);
+
+	// CPU snapshot FIRST (freeze our reference before any GPU work)
+	size_t map_len = (size_t) declared_pitch * H + frame.offset[0];
+	uint8_t *cpu = mmap(NULL, map_len, PROT_READ, MAP_SHARED, frame.dma_buf_fd[0], 0);
+	if (cpu == MAP_FAILED) {
+		fprintf(stderr, "mmap failed\n");
+		return 1;
+	}
+	uint8_t *snap = malloc(map_len);
+	memcpy(snap, cpu, map_len);
+
+	// GPU import
+	int gpu_fd = -1;
+	dir = opendir("/dev/dri");
+	while (dir && (entry = readdir(dir))) {
+		if (strncmp(entry->d_name, "renderD", 7))
+			continue;
+		char path[PATH_MAX];
+		snprintf(path, sizeof(path), "/dev/dri/%s", entry->d_name);
+		int fd = open(path, O_RDWR | O_CLOEXEC);
+		if (fd < 0)
+			continue;
+		drmVersionPtr ver = drmGetVersion(fd);
+		bool herm = ver && ver->name && !strcmp(ver->name, "hermes-kms");
+		if (ver)
+			drmFreeVersion(ver);
+		if (herm) {
+			close(fd);
+			continue;
+		}
+		gpu_fd = fd;
+		break;
+	}
+	if (dir)
+		closedir(dir);
+
+	struct gbm_device *gbm = gbm_create_device(gpu_fd);
+	PFNEGLGETPLATFORMDISPLAYEXTPROC gpd =
+		(PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress("eglGetPlatformDisplayEXT");
+	EGLDisplay dpy = gpd(EGL_PLATFORM_GBM_KHR, gbm, NULL);
+	eglInitialize(dpy, NULL, NULL);
+	eglBindAPI(EGL_OPENGL_API);
+	EGLContext ctx = eglCreateContext(dpy, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, NULL);
+	eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx);
+
+	EGLAttrib attribs[] = {
+		EGL_WIDTH, W,
+		EGL_HEIGHT, H,
+		EGL_LINUX_DRM_FOURCC_EXT, frame.format,
+		EGL_DMA_BUF_PLANE0_FD_EXT, frame.dma_buf_fd[0],
+		EGL_DMA_BUF_PLANE0_OFFSET_EXT, frame.offset[0],
+		EGL_DMA_BUF_PLANE0_PITCH_EXT, declared_pitch,
+		EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, (EGLAttrib) (frame.modifier & 0xFFFFFFFFu),
+		EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, (EGLAttrib) (frame.modifier >> 32),
+		EGL_NONE
+	};
+	EGLImage image = eglCreateImage(dpy, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
+	if (image == EGL_NO_IMAGE) {
+		fprintf(stderr, "import failed 0x%x\n", eglGetError());
+		return 1;
+	}
+
+	typedef void(GLAPIENTRY * TexStorageFn)(GLenum, void *, const GLint *);
+	TexStorageFn tex_storage = (TexStorageFn) eglGetProcAddress("glEGLImageTargetTexStorageEXT");
+	GLuint tex;
+	glGenTextures(1, &tex);
+	glBindTexture(GL_TEXTURE_2D, tex);
+	while (glGetError()) {}
+	glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+	const char *bind_path = "OES";
+	if (glGetError() != GL_NO_ERROR) {
+		glDeleteTextures(1, &tex);
+		glGenTextures(1, &tex);
+		glBindTexture(GL_TEXTURE_2D, tex);
+		tex_storage(GL_TEXTURE_2D, image, NULL);
+		bind_path = "TexStorageEXT";
+		if (glGetError() != GL_NO_ERROR) {
+			fprintf(stderr, "both binds failed\n");
+			return 1;
+		}
+	}
+	printf("bind path: %s\n", bind_path);
+
+	GLuint fbo;
+	glGenFramebuffers(1, &fbo);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
+
+	uint8_t *gpu_rows = malloc((size_t) W * 4 * 32);
+	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	glReadPixels(0, 0, W, 32, GL_BGRA, GL_UNSIGNED_BYTE, gpu_rows);
+	glFinish();
+
+	// Live desktop content can change a little between the CPU snapshot and
+	// the GPU readback, so compare byte-match FRACTIONS: a pitch shear
+	// misaligns everything, animation only touches small regions.
+	const uint32_t rows_to_check = H < 200 ? H : 200;
+	uint8_t *gpu_all = malloc((size_t) W * 4 * rows_to_check);
+	glReadPixels(0, 0, W, rows_to_check, GL_BGRA, GL_UNSIGNED_BYTE, gpu_all);
+	glFinish();
+
+	uint64_t eq_declared = 0, eq_tight = 0, total = 0;
+	for (uint32_t y = 0; y < rows_to_check; y++) {
+		const uint8_t *g = gpu_all + (size_t) y * W * 4;
+		const uint8_t *c_decl = snap + frame.offset[0] + (size_t) y * declared_pitch;
+		const uint8_t *c_tight = snap + frame.offset[0] + (size_t) y * tight_pitch;
+		for (uint32_t i = 0; i < W * 4; i++) {
+			eq_declared += (g[i] == c_decl[i]);
+			eq_tight += (g[i] == c_tight[i]);
+		}
+		total += W * 4;
+	}
+	printf("byte match vs declared pitch (%u): %.2f%%\n", declared_pitch, 100.0 * eq_declared / total);
+	printf("byte match vs tight pitch    (%u): %.2f%%\n", tight_pitch, 100.0 * eq_tight / total);
+
+	// More hypotheses: vertical flip, R/B channel swap, both.
+	uint64_t eq_flip = 0, eq_swap = 0, eq_flip_swap = 0;
+	for (uint32_t y = 0; y < rows_to_check; y++) {
+		const uint8_t *g = gpu_all + (size_t) y * W * 4;
+		const uint8_t *c = snap + frame.offset[0] + (size_t) y * declared_pitch;
+		const uint8_t *cf = snap + frame.offset[0] + (size_t) (H - 1 - y) * declared_pitch;
+		for (uint32_t px = 0; px < W; px++) {
+			const uint8_t *gp = g + px * 4;
+			const uint8_t *cp = c + px * 4;
+			const uint8_t *cfp = cf + px * 4;
+			eq_flip += (gp[0] == cfp[0]) + (gp[1] == cfp[1]) + (gp[2] == cfp[2]) + (gp[3] == cfp[3]);
+			eq_swap += (gp[0] == cp[2]) + (gp[1] == cp[1]) + (gp[2] == cp[0]) + (gp[3] == cp[3]);
+			eq_flip_swap += (gp[0] == cfp[2]) + (gp[1] == cfp[1]) + (gp[2] == cfp[0]) + (gp[3] == cfp[3]);
+		}
+	}
+	printf("byte match vs flipped rows:        %.2f%%\n", 100.0 * eq_flip / total);
+	printf("byte match vs R/B swapped:         %.2f%%\n", 100.0 * eq_swap / total);
+	printf("byte match vs flipped + swapped:   %.2f%%\n", 100.0 * eq_flip_swap / total);
+
+	// Drift-proof comparison: KWin reuses the acquired buffer for a later
+	// frame, so only rows whose CPU bytes are identical BEFORE and AFTER the
+	// GPU readback are trustworthy references.
+	{
+		const uint32_t y0 = H > 600 ? 400 : H / 4;
+		const uint32_t nrows = 200;
+		uint8_t *gpu_mid = malloc((size_t) W * 4 * nrows);
+		glReadPixels(0, y0, W, nrows, GL_BGRA, GL_UNSIGNED_BYTE, gpu_mid);
+		glFinish();
+		uint8_t *post = malloc(map_len);
+		memcpy(post, cpu, map_len);
+
+		uint32_t stable = 0, st_decl = 0, st_tight = 0, st_other = 0;
+		for (uint32_t r = 0; r < nrows && y0 + r < H; r++) {
+			const size_t off_decl = frame.offset[0] + (size_t) (y0 + r) * declared_pitch;
+			const size_t off_tight = frame.offset[0] + (size_t) (y0 + r) * tight_pitch;
+			if (memcmp(snap + off_decl, post + off_decl, W * 4))
+				continue;  // row changed while we were reading -> useless
+			stable++;
+			const uint8_t *g = gpu_mid + (size_t) r * W * 4;
+			if (!memcmp(g, snap + off_decl, W * 4))
+				st_decl++;
+			else if (off_tight + W * 4 <= map_len && !memcmp(g, snap + off_tight, W * 4))
+				st_tight++;
+			else
+				st_other++;
+		}
+		printf("drift-proof rows %u..%u: stable=%u  match_declared=%u  match_tight=%u  match_neither=%u\n",
+		       y0, y0 + nrows, stable, st_decl, st_tight, st_other);
+		if (stable && st_tight > st_decl)
+			printf("VERDICT: GPU reads with width*4 pitch -> import shear confirmed\n");
+		else if (stable && st_decl > st_tight)
+			printf("VERDICT: GPU honors declared pitch on stable rows\n");
+		free(gpu_mid);
+		free(post);
+	}
+
+	// Brute force: which pitch does the GPU's view actually correspond to?
+	// Sample busy rows mid-frame and scan candidate pitches.
+	{
+		const uint32_t y0 = H > 600 ? 500 : H / 2;
+		const uint32_t nrows = 24;
+		uint8_t *mid = malloc((size_t) W * 4 * nrows);
+		glReadPixels(0, y0, W, nrows, GL_BGRA, GL_UNSIGNED_BYTE, mid);
+		glFinish();
+
+		uint32_t best_pitch = 0;
+		double best_frac = -1.0, second_frac = -1.0;
+		uint32_t second_pitch = 0;
+		for (uint32_t P = tight_pitch - 64; P <= tight_pitch + 5200; P += 4) {
+			uint64_t eq = 0, tot = 0;
+			for (uint32_t r = 0; r < nrows; r += 4) {
+				const uint8_t *g = mid + (size_t) r * W * 4;
+				size_t off = frame.offset[0] + (size_t) (y0 + r) * P;
+				if (off + W * 4 > map_len)
+					break;
+				const uint8_t *c = snap + off;
+				for (uint32_t i = 0; i < W * 4; i += 4) {  // sample every pixel's B channel + G
+					eq += (g[i] == c[i]) + (g[i + 1] == c[i + 1]);
+					tot += 2;
+				}
+			}
+			double frac = tot ? (double) eq / tot : 0;
+			if (frac > best_frac) {
+				second_frac = best_frac;
+				second_pitch = best_pitch;
+				best_frac = frac;
+				best_pitch = P;
+			} else if (frac > second_frac) {
+				second_frac = frac;
+				second_pitch = P;
+			}
+		}
+		printf("brute-force pitch scan (rows %u..%u):\n", y0, y0 + nrows);
+		printf("  best pitch    = %u (%.2f%% match)%s\n", best_pitch, 100 * best_frac,
+		       best_pitch == declared_pitch ? "  <-- declared" : (best_pitch == tight_pitch ? "  <-- width*4" : ""));
+		printf("  second pitch  = %u (%.2f%% match)\n", second_pitch, 100 * second_frac);
+		free(mid);
+	}
+
+	printf("cpu row0[0..15]: ");
+	for (int i = 0; i < 16; i++)
+		printf("%02x ", snap[frame.offset[0] + i]);
+	printf("\ngpu row0[0..15]: ");
+	for (int i = 0; i < 16; i++)
+		printf("%02x ", gpu_all[i]);
+	printf("\ncpu row100[0..15]: ");
+	for (int i = 0; i < 16; i++)
+		printf("%02x ", snap[frame.offset[0] + (size_t) 100 * declared_pitch + i]);
+	printf("\ngpu row100[0..15]: ");
+	for (int i = 0; i < 16; i++)
+		printf("%02x ", gpu_all[(size_t) 100 * W * 4 + i]);
+	printf("\n");
+	free(gpu_all);
+
+	free(gpu_rows);
+	free(snap);
+	munmap(cpu, map_len);
+	eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	return 0;
+}


### PR DESCRIPTION
Companion to MrOz59/Hermes#16 (NVIDIA/NVENC support). Adds two self-contained diagnostic consumers under `tools/hermes-egl-import-check/`:

- **`hermes_egl_import_check.c`** — validates the NVENC-style consumer chain against a live frame: `ACQUIRE_FRAME` → `eglCreateImage(EGL_LINUX_DMA_BUF_EXT)` → texture bind (OES with `glEGLImageTargetTexStorageEXT` fallback) → FBO readback → GL blit into an own texture → `cuGraphicsGLRegisterImage` (mirrors the Hermes CUDA converter flow), with CRC cross-checks against the CPU view.
- **`pitch_detect.c`** — compares the GPU's view of the imported frame against the CPU view of the same DMA-BUF under several corruption hypotheses (declared pitch, width*4, vertical flip, R/B swap, brute-forced pitch scan, drift-filtered row comparison).

## Finding these tools document (NVIDIA 595.84, RTX 5060 Ti, kernel 7.1.4)

NVIDIA imports the driver's system-memory DMA-BUFs via `EGL_EXT_image_dma_buf_import` without error (the OES texture bind fails with `GL_INVALID_OPERATION`; the `GL_EXT_EGL_image_storage` bind succeeds), but sampled content is only correct for roughly the first contiguous ~2 MB of the buffer. Beyond that the GPU reads the wrong pages — visible as diagonal stripe corruption at larger modes — while `mmap` of the very same DMA-BUF on the CPU is pixel-perfect. Smaller framebuffers can appear to work when their pages happen to be allocated contiguously, which is why 1920x1080 looked fine and 2796x1290 didn't.

Consequence for consumers: the Hermes NVIDIA fork routes NVENC sessions through a CPU-copy path for now. If the driver could hand out physically contiguous framebuffer memory (or the root cause turns out to be fixable in the export path), true zero-copy NVENC would become viable — happy to help test either direction on this hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

