### PR TITLE
feat(hdr): advertise HDR to compositors via EDID metadata and connect…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ tools/hermes-cursor-probe/hermes_cursor_probe
 tools/hermes-pixel-peek/hermes_pixel_peek
 tools/hermes-sysmem-import-check/hermes-sysmem-import-check
 tools/hermes-imported-scanout-test/hermes-imported-scanout-test
+
+# Kiro spec-workflow artifacts and local working notes (not part of the driver source)
+.kiro/
+PR_hdr-static-metadata-support.md
+EXTERNAL_REVIEW.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,41 @@ subject to change between minor releases.
 
 ## [Unreleased]
 
+### Added
+
+- HDR advertisement from the virtual output. A compositor treats an output as
+  HDR-capable only through a two-gate chain, not a single signal. KWin, for
+  example, sets its `WideColorGamut` capability only when the connector exposes a
+  `Colorspace` property advertising BT2020 and the EDID reports BT2020 support
+  through a Colorimetry Data Block; only with `WideColorGamut` already set does it
+  then set `HighDynamicRange`, which additionally needs the `HDR_OUTPUT_METADATA`
+  property and an EDID HDR Static Metadata Data Block reporting PQ. Hermes
+  advertised none of these, so a virtual output always reported "HDR: incapable"
+  even next to a physical monitor streaming HDR correctly on the same GPU. An
+  earlier attempt that carried only the HDR Static Metadata block and the
+  `HDR_OUTPUT_METADATA` property still left HDR off on hardware, because the
+  BT2020 Colorimetry block and the `Colorspace` property were missing and the
+  `WideColorGamut` gate was therefore never satisfied. HDR now spans three
+  advertisement mechanisms: the EDID CTA-861 extension carries both an HDR Static
+  Metadata Data Block and a BT2020 Colorimetry Data Block, and the connector
+  exposes both the `HDR_OUTPUT_METADATA` property and a `Colorspace` property
+  advertising BT2020. The new `hdr_enable` module parameter (default off) gates
+  all of them as one unit — the CTA extension (both data blocks), the
+  `HDR_OUTPUT_METADATA` property, and the `Colorspace` property are present only
+  when it is set, and never a subset — so enabling HDR stays a deliberate opt-in
+  matching `color_depth`, `non_desktop` and the other load-time parameters.
+  Whether these advertisements alone are enough for KWin to enable HDR, or whether
+  `color_depth=10` must be set at the same time, is an untested-together
+  dependency: the two must be validated as a pair before deployment.
+  `tests/edid.c` covers the generated two-block EDID bytes — including the
+  Colorimetry block — and both block checksums under `make check`.
+  - Adding this parameter may warrant a `HERMES_KMS_DRIVER_MINOR` bump under the
+    versioning policy above, since it is a new load-time capability. The
+    canonical version lives in the three defines in
+    [`kernel/hermes-kms/hermes_kms.c`](kernel/hermes-kms/hermes_kms.c) that DKMS,
+    the PKGBUILD and `GET_VERSION` all read, so the number is left to the
+    maintainer cutting the release rather than fixed here.
+
 ### Fixed
 
 - An upgrade no longer leaves a working module reporting itself as unusable

--- a/README.md
+++ b/README.md
@@ -103,8 +103,16 @@ the output name prefix is `HERMES-` and the UAPI symbols are prefixed
 `HERMES_KMS_`.
 
 What is currently validated: VAAPI with `XRGB8888`, linear. NVENC/AMF and
-NV12/P010/HDR are not validated yet — see the [Roadmap](#roadmap). Forks and
-contributions extending those paths are welcome under the project's license.
+NV12/P010 are not validated yet — see the [Roadmap](#roadmap). HDR advertisement
+is now implemented but not yet validated end to end: with `hdr_enable=1` the
+synthetic EDID's CTA-861 extension carries both an HDR Static Metadata Data Block
+and a BT2020 Colorimetry Data Block, and the connector exposes both the
+`HDR_OUTPUT_METADATA` and `Colorspace` properties — the three signals a
+compositor needs together, since KWin gates HDR behind a wide-colour-gamut
+prerequisite (the `Colorspace` property plus BT2020 in the EDID) before it will
+enable high dynamic range. Full HDR streaming and the `color_depth=10` dependency
+are still open. Forks and contributions extending those paths are welcome under
+the project's license.
 
 The kernel module is GPL-2.0, while the installed UAPI has the Linux syscall-note
 exception and the optional userspace session helper is MIT-licensed. This keeps
@@ -152,6 +160,14 @@ an independently developed consumer separate from the Hermes application; see
   while keeping the framebuffer pitch independently aligned for DMA-BUF;
 - eight- and ten-bit scanout formats (`XRGB8888`/`ARGB8888` and the `2101010`
   variants), with the advertised EDID depth selected by `color_depth=`;
+- optional HDR advertisement (`hdr_enable=1`, default off), which adds both a
+  CTA-861 HDR Static Metadata Data Block and a BT2020 Colorimetry Data Block to
+  the synthetic EDID and attaches both the `HDR_OUTPUT_METADATA` and `Colorspace`
+  (advertising BT2020) connector properties together, so a compositor sees all
+  three signals it needs to treat the output as HDR-capable — KWin, for example,
+  requires the `Colorspace` property plus BT2020 in the EDID for its
+  wide-colour-gamut prerequisite before it will enable HDR. Untested together
+  with `color_depth=10`; validate that pairing before deployment;
 - scanout modifier pass-through: any tiled or compressed layout the compositor's
   render GPU produces is accepted, and `scanout_modifiers=` publishes the extra
   layouts an `IN_FORMATS`-driven compositor can negotiate;
@@ -327,6 +343,41 @@ sudo insmod kernel/hermes-kms/hermes_kms.ko initial_enabled=0 outputs=2
 sudo insmod kernel/hermes-kms/hermes_kms.ko initial_enabled=0 devices=2 outputs=1
 sudo insmod kernel/hermes-kms/hermes_kms.ko initial_enabled=0 session_devices=4 outputs=1
 ```
+
+`hdr_enable=1` advertises HDR (default off). It gates three mechanisms together —
+the CTA-861 HDR Static Metadata Data Block and the BT2020 Colorimetry Data Block
+in the EDID, and the `HDR_OUTPUT_METADATA` and `Colorspace` connector
+properties — so the output never advertises a subset. All three are needed
+because KWin treats an output HDR-capable through a two-gate chain: it sets
+`WideColorGamut` only when the connector has a `Colorspace` property advertising
+BT2020 and the EDID reports BT2020 (the Colorimetry block), and only then sets
+`HighDynamicRange`, which additionally needs `HDR_OUTPUT_METADATA` and the EDID's
+PQ HDR Static Metadata block. An earlier attempt carrying only the HDR Static
+Metadata block and `HDR_OUTPUT_METADATA` left HDR off on hardware precisely
+because the Colorimetry block and `Colorspace` property were missing. Whether
+these advertisements alone are enough for a compositor to enable HDR, or whether
+ten-bit scanout (`color_depth=10`) must be set at the same time, is not yet
+confirmed; the combination is untested together and must be validated before
+deployment. To load HDR together with ten-bit scanout:
+
+```bash
+sudo modprobe hermes_kms color_depth=10 hdr_enable=1
+```
+
+To apply the same parameters persistently at every module load, drop a file in
+`/etc/modprobe.d`:
+
+```
+# /etc/modprobe.d/hermes-kms-hdr.conf
+options hermes_kms color_depth=10 hdr_enable=1
+```
+
+During verification, compare two configurations to determine empirically whether
+the advertisement alone is sufficient: (a) `hdr_enable=1` without `color_depth=10`,
+and (b) `hdr_enable=1` with `color_depth=10`. If a consumer still reports
+"HDR: incapable" after all three mechanisms are applied and `color_depth=10` is
+set, CRTC color-management properties are the next investigation area — that is
+outside this feature's scope and no further code change is made here.
 
 Independent compositors use the packaged
 `72-hermes-kms-session-seats.rules` and one private seat broker per session

--- a/docs/driver-design.md
+++ b/docs/driver-design.md
@@ -48,6 +48,25 @@ accept, and the synthetic EDID advertises eight bits per primary unless
 `color_depth=` says otherwise. Raising it is therefore a deliberate choice, and
 consumers must be prepared for a ten-bit fourcc when it is made.
 
+HDR advertisement itself is implemented, gated behind `hdr_enable` (default off).
+When set, the synthetic EDID gains a CTA-861 extension block carrying both an HDR
+Static Metadata Data Block (PQ) and a BT2020 Colorimetry Data Block, and the
+connector attaches both the `HDR_OUTPUT_METADATA` property and a `Colorspace`
+property advertising BT2020 — the three signals a compositor requires together to
+treat the output as HDR-capable, always enabled or disabled as one unit. Three
+are needed because KWin treats an output HDR-capable through a two-gate chain: it
+sets `WideColorGamut` only when the connector has a `Colorspace` property
+advertising BT2020 and the EDID reports BT2020 (via the Colorimetry block), and
+only then sets `HighDynamicRange`, which additionally needs `HDR_OUTPUT_METADATA`
+and the EDID's PQ HDR Static Metadata block. An earlier iteration carrying only
+the HDR Static Metadata block and `HDR_OUTPUT_METADATA` left HDR off on hardware
+because the Colorimetry block and `Colorspace` property were missing, so the
+`WideColorGamut` gate was never satisfied. This is the advertisement only:
+whether ten-bit scanout (`color_depth=10`) must be set simultaneously for a
+compositor to actually enable HDR is an untested-together dependency, and full
+HDR streaming validation remains open. `hdr_enable` and `color_depth=10` must be
+validated together before deployment.
+
 ### Scanout layouts
 
 The driver never samples a scanout pixel: it latches the framebuffer, holds a
@@ -625,6 +644,10 @@ The module supports these topology and initial-state parameters:
   plus a host card, mutually exclusive with an explicit `devices` topology)
 - `hotplug_events`
 - `non_desktop`
+- `hdr_enable` (advertise HDR; gates a CTA-861 EDID extension carrying both an
+  HDR Static Metadata block and a BT2020 Colorimetry block, plus the
+  `HDR_OUTPUT_METADATA` and `Colorspace` connector properties, all together;
+  default off, load-time only, untested together with `color_depth=10`)
 - `scanout_modifiers` (up to 15 extra `IN_FORMATS` layouts; linear is always
   advertised and every modifier is accepted regardless of this list)
 
@@ -707,6 +730,46 @@ Not yet implemented:
 
 - a real DRM writeback connector;
 - NVENC/AMF import validation (VAAPI is validated);
-- NV12/P010 scanout and HDR (the compositor composes in RGB; the encoder does
-  RGB→NV12 on the real GPU today);
+- NV12/P010 scanout (the compositor composes in RGB; the encoder does RGB→NV12
+  on the real GPU today);
 - full compositor recovery handling beyond owner-fd disconnect and hotplug.
+
+Implemented but not yet validated end to end: HDR advertisement. With
+`hdr_enable=1` the synthetic EDID's CTA-861 extension carries both an HDR Static
+Metadata Data Block (PQ) and a BT2020 Colorimetry Data Block, and the connector
+exposes both the `HDR_OUTPUT_METADATA` property and a `Colorspace` property
+advertising BT2020, so a compositor sees all three signals it needs to treat the
+output as HDR-capable. Three are required because KWin gates HDR behind a
+two-gate chain: `WideColorGamut` (needing the `Colorspace` property advertising
+BT2020 plus EDID BT2020 support from the Colorimetry block) is a prerequisite for
+`HighDynamicRange` (needing `HDR_OUTPUT_METADATA` plus the EDID's PQ HDR Static
+Metadata block). The first iteration, which carried only the HDR Static Metadata
+block and `HDR_OUTPUT_METADATA`, left HDR off on hardware because the Colorimetry
+block and `Colorspace` property were missing. `tests/edid.c` covers the generated
+EDID bytes — including the Colorimetry block — and both block checksums under
+`make check`. What remains open is full HDR streaming validation and the
+`color_depth=10` dependency: it is not yet confirmed whether the EDID and
+property change alone enable HDR in the compositor, or whether ten-bit scanout
+must be set simultaneously.
+
+To load HDR together with ten-bit scanout:
+
+```bash
+sudo modprobe hermes_kms color_depth=10 hdr_enable=1
+```
+
+To apply these parameters persistently at every module load, drop a file in
+`/etc/modprobe.d`:
+
+```
+# /etc/modprobe.d/hermes-kms-hdr.conf
+options hermes_kms color_depth=10 hdr_enable=1
+```
+
+Two configurations must be compared during verification to resolve the
+dependency empirically: (a) `hdr_enable=1` without `color_depth=10`, and (b)
+`hdr_enable=1` with `color_depth=10`. If a Consumer still reports "HDR: incapable"
+after all three mechanisms are applied and `color_depth=10` is set, CRTC
+color-management properties (gamma LUT, degamma LUT, CTM, COLOR_PIPELINE) are the
+next investigation area. That is outside this feature's scope, and no further
+code change is made here in response to that condition.

--- a/kernel/hermes-kms/hermes_kms.c
+++ b/kernel/hermes-kms/hermes_kms.c
@@ -147,6 +147,7 @@
 static bool initial_enabled;
 static bool hotplug_events = true;
 static bool non_desktop;
+static bool hdr_enable;
 static bool insecure_legacy_unbound_access;
 static unsigned int initial_width = HERMES_KMS_DEFAULT_WIDTH;
 static unsigned int initial_height = HERMES_KMS_DEFAULT_HEIGHT;
@@ -162,6 +163,9 @@ module_param(hotplug_events, bool, 0644);
 MODULE_PARM_DESC(hotplug_events, "Emit DRM hotplug events when output state changes");
 module_param(non_desktop, bool, 0444);
 MODULE_PARM_DESC(non_desktop, "Mark connector as non-desktop. Default false so compositors can manage Hermes as a normal virtual monitor when connected");
+module_param(hdr_enable, bool, 0444);
+MODULE_PARM_DESC(hdr_enable,
+		 "Advertise HDR via a CTA-861 EDID extension (HDR Static Metadata + BT2020 Colorimetry data blocks) plus the HDR_OUTPUT_METADATA and Colorspace connector properties. Default false. Untested together with color_depth=10; validate that pairing before deployment");
 /*
  * Load-time only, deliberately. At 0600 root could widen every output's capture
  * access on a live system, silently and mid-session: hermes_kms_file_has_access
@@ -286,7 +290,7 @@ struct hermes_kms_output {
 	/* Globally unique identity from hermes_kms_output_ida, or -1. */
 	int identity;
 	char output_name[HERMES_KMS_NAME_LEN];
-	u8 edid[128];
+	u8 edid[2 * HERMES_KMS_EDID_SIZE];
 	/*
 	 * Explicit KMS objects (CRTC + encoder + primary plane), rather than
 	 * drm_simple_display_pipe, so we can drive a software vblank timer the
@@ -707,9 +711,27 @@ static bool hermes_kms_build_output_edid(struct hermes_kms_output *output,
 		.color_depth = color_depth,
 	};
 
-	static_assert(sizeof(output->edid) == HERMES_KMS_EDID_SIZE);
+	bool representable;
 
-	return hermes_kms_build_edid(output->edid, serial, &config);
+	/*
+	 * The buffer holds a base block plus one CTA-861 extension block, so it
+	 * must be exactly two EDID blocks wide. This guards the HDR extension
+	 * append below against a buffer that is too small to hold both blocks.
+	 */
+	static_assert(sizeof(output->edid) == 2 * HERMES_KMS_EDID_SIZE);
+
+	representable = hermes_kms_build_edid(output->edid, serial, &config);
+
+	/*
+	 * When HDR advertisement is enabled, promote the single base block into
+	 * a two-block EDID by flipping the base extension count and appending a
+	 * CTA-861 HDR Static Metadata extension. This is a side effect on the
+	 * buffer; the return value stays the base builder's representable flag.
+	 */
+	if (hdr_enable)
+		hermes_kms_append_hdr_extension(output->edid);
+
+	return representable;
 }
 
 static bool hermes_kms_hotplug_event(struct hermes_kms_output *output)
@@ -3872,6 +3894,38 @@ static int hermes_kms_output_modeset_init(struct hermes_kms_output *output)
 	drm_connector_attach_edid_property(&output->connector);
 
 	/*
+	 * HDR advertisement needs the EDID CTA extension (HDR Static Metadata +
+	 * BT2020 Colorimetry blocks, built when hdr_enable is set) together with
+	 * two connector properties: HDR_OUTPUT_METADATA, so a compositor has
+	 * somewhere to write HDR output state, and Colorspace, so it can select
+	 * BT2020. Gated by the same hdr_enable flag so all three mechanisms are
+	 * always enabled together.
+	 */
+	if (hdr_enable) {
+		ret = drm_connector_attach_hdr_output_metadata_property(&output->connector);
+		if (ret)
+			return ret;
+
+		/*
+		 * KWin gates HDR behind Capability::WideColorGamut, which needs a
+		 * connector "Colorspace" property advertising BT2020 (together with
+		 * the EDID's BT2020 Colorimetry block) before it will set
+		 * HighDynamicRange. Create and attach it here so all three HDR
+		 * advertisement mechanisms flip together with hdr_enable.
+		 */
+		ret = drm_mode_create_hdmi_colorspace_property(
+			&output->connector,
+			BIT(DRM_MODE_COLORIMETRY_BT2020_RGB) |
+			BIT(DRM_MODE_COLORIMETRY_DEFAULT));
+		if (ret)
+			return ret;
+
+		ret = drm_connector_attach_colorspace_property(&output->connector);
+		if (ret)
+			return ret;
+	}
+
+	/*
 	 * Do not set the connector PATH property here. That property is
 	 * reserved for DP-MST tunnelled connectors: drm_connector_set_path_property()
 	 * returns -EINVAL on a plain DRM_MODE_CONNECTOR_VIRTUAL connector, and a
@@ -4825,6 +4879,17 @@ static void __init hermes_kms_sanitize_mode_range(void)
 			HERMES_KMS_DEFAULT_COLOR_DEPTH);
 		color_depth = HERMES_KMS_DEFAULT_COLOR_DEPTH;
 	}
+
+	/*
+	 * HDR advertisement and ten-bit scanout are an untested-together
+	 * dependency: it is not yet confirmed whether the EDID/property change
+	 * alone enables HDR in the compositor or whether color_depth=10 must be
+	 * set at the same time. Surface the pairing without forcing it -- the
+	 * user's color_depth choice is left exactly as configured.
+	 */
+	if (hdr_enable && color_depth < 10)
+		pr_info("%s: hdr_enable=1 with color_depth=%u (<10); HDR advertisement and ten-bit scanout are untested together, validate the pairing before deployment\n",
+			HERMES_KMS_DRIVER_NAME, color_depth);
 
 	if (min_width != requested_min_width ||
 	    min_height != requested_min_height ||

--- a/kernel/hermes-kms/hermes_kms_edid.h
+++ b/kernel/hermes-kms/hermes_kms_edid.h
@@ -49,7 +49,53 @@ typedef uint64_t u64;
 #define HERMES_KMS_EDID_FEATURES_OFFSET		24
 #define HERMES_KMS_EDID_DTD_OFFSET		54
 #define HERMES_KMS_EDID_RANGE_OFFSET		90
+#define HERMES_KMS_EDID_EXT_COUNT_OFFSET	126
 #define HERMES_KMS_EDID_CHECKSUM_OFFSET		127
+
+/*
+ * CTA-861 extension header, carried in the second EDID block. A compositor
+ * treats an output as HDR-capable only when both an EDID HDR Static Metadata
+ * Data Block and the HDR_OUTPUT_METADATA connector property are present, and
+ * KWin additionally gates HDR behind a BT2020 Colorimetry Data Block, so the
+ * extension carries both data blocks. Tag 0x02 marks a CTA extension; the DTD
+ * offset says "no detailed timings" and points past the data block collection.
+ *
+ * The DTD offset equals 4 (the CTA header) plus the byte length of the data
+ * block collection: an HDR Static Metadata block (4 bytes) followed by a
+ * Colorimetry block (4 bytes) gives 4 + 8 = 12. With no detailed timings, this
+ * also marks where the zero padding begins.
+ */
+#define HERMES_KMS_CTA_TAG		0x02	/* extension block[0] */
+#define HERMES_KMS_CTA_REVISION		0x03	/* extension block[1] */
+#define HERMES_KMS_CTA_DTD_OFFSET	0x0c	/* extension block[2]: 4 + 8-byte collection */
+
+/*
+ * The HDR Static Metadata Data Block is a CTA "use extended tag" data block:
+ * the top three bits of its tag/length byte select the extended-tag block
+ * type (0x07), and the extended tag byte that follows (0x06) identifies it as
+ * HDR Static Metadata (CTA-861.3).
+ */
+#define HERMES_KMS_CTA_TAG_EXTENDED	0x07	/* tag/length byte, bits 7:5 */
+#define HERMES_KMS_CTA_EXT_TAG_HDR_SM	0x06	/* HDR static metadata */
+
+/*
+ * The Colorimetry Data Block is another CTA "use extended tag" data block
+ * (extended tag 0x05). Its colorimetry byte advertises supported extended
+ * colorimetry encodings; bit 7 signals BT2020 RGB, which is what makes KWin's
+ * edid()->supportsBT2020() return true.
+ */
+#define HERMES_KMS_CTA_EXT_TAG_COLORIMETRY	0x05	/* colorimetry data block */
+#define HERMES_KMS_COLORIMETRY_BT2020_RGB	0x80	/* colorimetry byte, bit 7 */
+
+/*
+ * EOTF support flags in the HDR Static Metadata Data Block. Traditional SDR
+ * gamma and SMPTE ST2084 (PQ) are advertised together so PQ is never offered
+ * without a defined SDR fallback; HERMES_KMS_HDR_SM_TYPE1 declares support for
+ * Static Metadata Descriptor Type 1.
+ */
+#define HERMES_KMS_HDR_EOTF_SDR_GAMMA	0x01	/* traditional gamma SDR */
+#define HERMES_KMS_HDR_EOTF_ST2084_PQ	0x04	/* SMPTE ST2084 (PQ) */
+#define HERMES_KMS_HDR_SM_TYPE1		0x01	/* Static Metadata Descriptor Type 1 */
 
 /*
  * CVT keeps the vertical blanking interval at least 550 us long, so the number
@@ -288,6 +334,117 @@ hermes_kms_build_edid(u8 *edid, u32 serial,
 	edid[HERMES_KMS_EDID_CHECKSUM_OFFSET] = (u8)-checksum;
 
 	return representable;
+}
+
+/*
+ * Build the CTA-861 extension block (the second EDID block) carrying an HDR
+ * Static Metadata Data Block into @block, which must have room for
+ * HERMES_KMS_EDID_SIZE bytes.
+ *
+ * A compositor only treats an output as HDR-capable when it finds an HDR
+ * Static Metadata Data Block in the EDID, and KWin's WideColorGamut gate --
+ * a prerequisite it requires before it will enable HDR at all -- additionally
+ * needs edid()->supportsBT2020() to return true, which comes from a BT2020
+ * Colorimetry Data Block, working alongside the connector's Colorspace
+ * property. So this block carries two data blocks back to back: the HDR
+ * Static Metadata block then the Colorimetry block. The CTA header advertises
+ * no native video formats and a DTD offset of 12, which spans the CTA header
+ * plus both 4-byte data blocks; everything after byte 12 is zero padding to
+ * the checksum.
+ *
+ * The EOTF byte is written from a single combined constant that always sets
+ * the traditional-SDR-gamma bit together with the SMPTE ST2084 (PQ) bit, so
+ * the block can never advertise PQ without a defined SDR fallback -- the one
+ * cross-flag invariant CTA-861.3 expects. The Colorimetry block sets only the
+ * BT2020 RGB bit and no gamut-metadata bits. The checksum at offset 127 is
+ * chosen so all 128 bytes sum to 0 mod 256, matching the base block's own
+ * checksum rule; without it the block is silently dropped by EDID parsers.
+ */
+static inline void hermes_kms_build_edid_hdr_extension(u8 *block)
+{
+	u8 checksum = 0;
+	unsigned int i;
+
+	/* CTA-861 extension header. */
+	block[0] = HERMES_KMS_CTA_TAG;
+	block[1] = HERMES_KMS_CTA_REVISION;
+	block[2] = HERMES_KMS_CTA_DTD_OFFSET;
+	block[3] = 0x00; /* no native formats, no flags */
+
+	/*
+	 * HDR Static Metadata Data Block (bytes 4..7): a use-extended-tag data
+	 * block whose tag/length byte selects the extended-tag type (top three
+	 * bits 0x07) and declares three payload bytes following it, the
+	 * extended tag identifies it as HDR Static Metadata (0x06), the EOTF
+	 * byte offers SDR gamma and ST2084/PQ together, and the descriptor byte
+	 * declares Static Metadata Descriptor Type 1.
+	 */
+	block[4] = (u8)((HERMES_KMS_CTA_TAG_EXTENDED << 5) | 3);
+	block[5] = HERMES_KMS_CTA_EXT_TAG_HDR_SM;
+	block[6] = HERMES_KMS_HDR_EOTF_SDR_GAMMA | HERMES_KMS_HDR_EOTF_ST2084_PQ;
+	block[7] = HERMES_KMS_HDR_SM_TYPE1;
+
+	/*
+	 * Colorimetry Data Block (bytes 8..11): another use-extended-tag data
+	 * block with three payload bytes; the extended tag identifies it as
+	 * Colorimetry (0x05), the colorimetry byte sets only the BT2020 RGB bit,
+	 * and the final gamut-metadata byte sets no bits.
+	 */
+	block[8] = (u8)((HERMES_KMS_CTA_TAG_EXTENDED << 5) | 3);
+	block[9] = HERMES_KMS_CTA_EXT_TAG_COLORIMETRY;
+	block[10] = HERMES_KMS_COLORIMETRY_BT2020_RGB;
+	block[11] = 0x00; /* no gamut-metadata bits */
+
+	/* Zero the padding region up to the checksum byte. */
+	for (i = HERMES_KMS_CTA_DTD_OFFSET; i < HERMES_KMS_EDID_CHECKSUM_OFFSET; i++)
+		block[i] = 0x00;
+
+	for (i = 0; i < HERMES_KMS_EDID_CHECKSUM_OFFSET; i++)
+		checksum += block[i];
+	block[HERMES_KMS_EDID_CHECKSUM_OFFSET] = (u8)-checksum;
+}
+
+/*
+ * Promote a finalized single-block base EDID in @edid into a two-block EDID
+ * that advertises HDR: flip the base block's extension-count byte to 1, fix up
+ * the base checksum, and build the CTA extension block into the second block.
+ * @edid must have room for 2 * HERMES_KMS_EDID_SIZE bytes.
+ *
+ * The base block's extension-count byte (offset 126) tells the EDID parser how
+ * many trailing blocks to read, so it must move from 0 to 1 in lockstep with
+ * the checksum: raising byte 126 by one raises the running sum by one, so the
+ * checksum byte drops by exactly one to keep all 128 bytes summing to 0 mod
+ * 256. Recomputing (rather than blindly decrementing) keeps this correct even
+ * if the base block ever changes, and it stays byte-for-byte equal to
+ * "old checksum - 1 mod 256" because that is the only value that preserves the
+ * invariant.
+ *
+ * Guard first: a valid base block already sums to 0 mod 256, and appending an
+ * extension to a broken base would only produce a broken two-block EDID. So if
+ * the incoming base does not already sum to 0, refuse -- return false and
+ * leave the extension region (edid[128..255]) untouched -- rather than
+ * "finalizing" garbage.
+ */
+static inline bool hermes_kms_append_hdr_extension(u8 *edid)
+{
+	u8 sum = 0;
+	unsigned int i;
+
+	for (i = 0; i < HERMES_KMS_EDID_SIZE; i++)
+		sum += edid[i];
+	if (sum != 0)
+		return false;
+
+	edid[HERMES_KMS_EDID_EXT_COUNT_OFFSET] = 1;
+
+	sum = 0;
+	for (i = 0; i < HERMES_KMS_EDID_CHECKSUM_OFFSET; i++)
+		sum += edid[i];
+	edid[HERMES_KMS_EDID_CHECKSUM_OFFSET] = (u8)-sum;
+
+	hermes_kms_build_edid_hdr_extension(&edid[HERMES_KMS_EDID_SIZE]);
+
+	return true;
 }
 
 #endif /* HERMES_KMS_EDID_H */

--- a/tests/edid.c
+++ b/tests/edid.c
@@ -175,6 +175,267 @@ static void check_color_depth(void)
 	}
 }
 
+/*
+ * Validate the CTA-861 extension block (the second EDID block) independently of
+ * the builder, mirroring how an EDID parser would decode it rather than reusing
+ * hermes_kms_build_edid_hdr_extension()'s own constants, so an inconsistent
+ * generator is caught instead of reproduced.
+ *
+ * Exercises Property 2 (the block sums to 0 mod 256), Property 4 (the EOTF byte
+ * sets the traditional-SDR-gamma and SMPTE ST2084/PQ bits together and never PQ
+ * without SDR gamma), and Property 6 (the HDR data block identity: a
+ * use-extended-tag data block with extended tag 0x06 declaring Static Metadata
+ * Descriptor Type 1).
+ *
+ * It also exercises Property 10 (the Colorimetry data block at bytes 8..11 is
+ * well-formed: 0xE3, 0x05, 0x80, 0x00), Property 11 (both data blocks are
+ * present and the DTD offset points past them at 12), and Property 12 (the CTA
+ * checksum sums to 0 mod 256 with both data blocks present -- the checksum
+ * check above now covers both blocks).
+ */
+static void check_cta_extension(const u8 *block, const char *what)
+{
+	unsigned int checksum = 0;
+	u8 tag_length;
+	u8 payload_length;
+	u8 eotf;
+	unsigned int i;
+
+	for (i = 0; i < HERMES_KMS_EDID_SIZE; i++)
+		checksum += block[i];
+	CHECK((checksum & 0xff) == 0,
+	      "%s: CTA extension checksum does not sum to zero", what);
+
+	/*
+	 * CTA-861 extension header: tag 0x02, DTD offset 12 (no detailed
+	 * timings; the offset points past the 4-byte CTA header plus the two
+	 * 4-byte data blocks that make up the 8-byte data block collection).
+	 */
+	CHECK(block[0] == 0x02,
+	      "%s: CTA extension tag is 0x%02x, expected 0x02", what, block[0]);
+	CHECK(block[2] == 0x0c,
+	      "%s: CTA DTD offset is 0x%02x, expected 0x0c (no detailed timings, past both data blocks)",
+	      what, block[2]);
+
+	/*
+	 * The data block collection starts at byte 4. Decode the tag/length
+	 * byte the way CTA-861 specifies: bits 7:5 are the block type and bits
+	 * 4:0 the number of payload bytes that follow.
+	 */
+	tag_length = block[4];
+	payload_length = tag_length & 0x1f;
+	CHECK((tag_length >> 5) == 0x07,
+	      "%s: data block type is %u, expected 0x07 (use extended tag)",
+	      what, tag_length >> 5);
+	CHECK(payload_length == 3,
+	      "%s: HDR data block declares %u payload bytes, expected 3",
+	      what, payload_length);
+
+	/* Extended tag 0x06 identifies the block as HDR Static Metadata. */
+	CHECK(block[5] == 0x06,
+	      "%s: extended tag is 0x%02x, expected 0x06 (HDR static metadata)",
+	      what, block[5]);
+
+	/*
+	 * EOTF byte: bit 0 is traditional SDR gamma, bit 2 is SMPTE ST2084
+	 * (PQ). Both must be set (0x05), and PQ must never appear without SDR
+	 * gamma.
+	 */
+	eotf = block[6];
+	CHECK(eotf == 0x05,
+	      "%s: EOTF byte is 0x%02x, expected 0x05 (SDR gamma + ST2084/PQ)",
+	      what, eotf);
+	CHECK(eotf & 0x01,
+	      "%s: traditional SDR gamma EOTF bit must be set", what);
+	CHECK(eotf & 0x04,
+	      "%s: SMPTE ST2084 (PQ) EOTF bit must be set", what);
+	CHECK(!(eotf & 0x04) || (eotf & 0x01),
+	      "%s: PQ EOTF must never be set without SDR gamma", what);
+
+	/* Descriptor byte declares Static Metadata Descriptor Type 1. */
+	CHECK(block[7] == 0x01,
+	      "%s: descriptor type byte is 0x%02x, expected 0x01",
+	      what, block[7]);
+
+	/*
+	 * The Colorimetry Data Block follows immediately at bytes 8..11.
+	 * Decode its tag/length byte the same way as the HDR block above: bits
+	 * 7:5 are the block type (0x07, use extended tag) and bits 4:0 the
+	 * payload length (3 bytes following).
+	 */
+	tag_length = block[8];
+	payload_length = tag_length & 0x1f;
+	CHECK((tag_length >> 5) == 0x07,
+	      "%s: colorimetry block type is %u, expected 0x07 (use extended tag)",
+	      what, tag_length >> 5);
+	CHECK(payload_length == 3,
+	      "%s: colorimetry block declares %u payload bytes, expected 3",
+	      what, payload_length);
+
+	/* Extended tag 0x05 identifies the block as Colorimetry. */
+	CHECK(block[9] == 0x05,
+	      "%s: colorimetry extended tag is 0x%02x, expected 0x05",
+	      what, block[9]);
+
+	/*
+	 * Colorimetry byte: bit 7 is BT2020 RGB. It must be the only bit set,
+	 * so the whole byte reads 0x80 -- KWin's supportsBT2020() only checks
+	 * for BT2020 RGB and the block advertises nothing else.
+	 */
+	CHECK(block[10] == 0x80,
+	      "%s: colorimetry byte is 0x%02x, expected 0x80 (BT2020 RGB only)",
+	      what, block[10]);
+	CHECK(block[10] & 0x80,
+	      "%s: BT2020 RGB colorimetry bit must be set", what);
+
+	/* Gamut-metadata byte advertises no supported bits. */
+	CHECK(block[11] == 0x00,
+	      "%s: gamut-metadata byte is 0x%02x, expected 0x00",
+	      what, block[11]);
+}
+
+/*
+ * Validate the two-block coupling between the base block and the appended CTA
+ * extension. Build a single-block base EDID, record its pre-append checksum,
+ * then promote it with hermes_kms_append_hdr_extension() and check that the
+ * base block is still well-formed while the extension-count and checksum bytes
+ * moved together.
+ *
+ * Exercises Property 1 (the base block sums to 0 mod 256 both before and after
+ * the extension is appended -- check_structure() re-runs the base-block
+ * checks), Property 3 (base byte 126 becomes 1 and base byte 127 becomes its
+ * pre-append value minus 1 mod 256), and Property 5 (the appended extension
+ * block is exactly HERMES_KMS_EDID_SIZE bytes and the whole buffer is exactly
+ * 2 * HERMES_KMS_EDID_SIZE bytes). check_cta_extension() covers the extension
+ * block's own well-formedness.
+ */
+static void check_base_with_extension(const struct hermes_kms_edid_config *config,
+				      const char *what)
+{
+	u8 edid[2 * HERMES_KMS_EDID_SIZE];
+	u8 pre_append_checksum;
+	bool appended;
+
+	CHECK(sizeof(edid) == 2 * HERMES_KMS_EDID_SIZE,
+	      "%s: EDID buffer must be exactly two blocks", what);
+
+	hermes_kms_build_edid(edid, 1, config);
+
+	/* The base block must be valid before the extension is appended. */
+	check_structure(edid, what);
+	CHECK(edid[HERMES_KMS_EDID_EXT_COUNT_OFFSET] == 0,
+	      "%s: single-block base must have extension count 0", what);
+	pre_append_checksum = edid[HERMES_KMS_EDID_CHECKSUM_OFFSET];
+
+	appended = hermes_kms_append_hdr_extension(edid);
+	CHECK(appended, "%s: appending the extension to a valid base must succeed",
+	      what);
+
+	/* Property 1: the base block is still well-formed after the append. */
+	check_structure(edid, what);
+
+	/* Property 3: extension-count and checksum move together. */
+	CHECK(edid[HERMES_KMS_EDID_EXT_COUNT_OFFSET] == 1,
+	      "%s: base extension count is %u, expected 1", what,
+	      edid[HERMES_KMS_EDID_EXT_COUNT_OFFSET]);
+	CHECK(edid[HERMES_KMS_EDID_CHECKSUM_OFFSET] ==
+		      (u8)(pre_append_checksum - 1),
+	      "%s: base checksum is 0x%02x, expected 0x%02x (pre-append minus 1)",
+	      what, edid[HERMES_KMS_EDID_CHECKSUM_OFFSET],
+	      (u8)(pre_append_checksum - 1));
+
+	/* Property 5 / Property 2,4,6: the appended extension block is valid. */
+	check_cta_extension(&edid[HERMES_KMS_EDID_SIZE], what);
+}
+
+/*
+ * Validate the finalize guard: a base block that does not already sum to 0 mod
+ * 256 is not a valid EDID, and promoting it into a two-block EDID would only
+ * produce a broken result. So hermes_kms_append_hdr_extension() must refuse a
+ * corrupt base and leave the extension region exactly as it found it.
+ *
+ * Build a valid base, paint the extension region (edid[128..255]) with a known
+ * sentinel pattern and snapshot it, then deliberately corrupt one base byte so
+ * the base no longer sums to 0 mod 256. The append must return false and the
+ * extension region must be byte-identical to the snapshot afterwards.
+ *
+ * Exercises Property 7 (finalize refuses an invalid base and does not touch the
+ * extension region).
+ */
+static void check_invalid_base_refused(const struct hermes_kms_edid_config *config,
+				       const char *what)
+{
+	u8 edid[2 * HERMES_KMS_EDID_SIZE];
+	u8 snapshot[HERMES_KMS_EDID_SIZE];
+	unsigned int checksum = 0;
+	bool appended;
+	unsigned int i;
+
+	hermes_kms_build_edid(edid, 1, config);
+
+	/*
+	 * Fill the extension region with a recognisable pattern and snapshot it
+	 * so a refused append is provably a no-op there rather than merely
+	 * leaving zeroes behind.
+	 */
+	for (i = 0; i < HERMES_KMS_EDID_SIZE; i++) {
+		u8 pattern = (u8)(0xa5 ^ i);
+
+		edid[HERMES_KMS_EDID_SIZE + i] = pattern;
+		snapshot[i] = pattern;
+	}
+
+	/*
+	 * Corrupt the base so it no longer sums to 0 mod 256. Flipping the low
+	 * bit of the first byte perturbs the sum by exactly 1, guaranteeing an
+	 * invalid checksum without depending on any other byte.
+	 */
+	edid[0] ^= 0x01;
+	for (i = 0; i < HERMES_KMS_EDID_SIZE; i++)
+		checksum += edid[i];
+	CHECK((checksum & 0xff) != 0,
+	      "%s: corrupted base must not sum to zero", what);
+
+	appended = hermes_kms_append_hdr_extension(edid);
+	CHECK(!appended,
+	      "%s: appending to an invalid base must fail", what);
+
+	/* The extension region must be untouched byte-for-byte. */
+	for (i = 0; i < HERMES_KMS_EDID_SIZE; i++)
+		CHECK(edid[HERMES_KMS_EDID_SIZE + i] == snapshot[i],
+		      "%s: extension byte %u changed to 0x%02x, expected 0x%02x",
+		      what, i, edid[HERMES_KMS_EDID_SIZE + i], snapshot[i]);
+}
+
+/*
+ * Validate the HDR-disabled path. With hdr_enable off the driver never calls
+ * hermes_kms_append_hdr_extension(), so the EDID it publishes is exactly the
+ * single base block hermes_kms_build_edid() produces: extension-count byte 0
+ * and a base block that stands on its own. This check builds precisely that --
+ * the base block with no append -- so it is byte-identical to the pre-feature
+ * output, and confirms the extension-count byte stays 0.
+ *
+ * Exercises Property 8 (the disabled path is byte-identical to the base-only
+ * EDID: a single base block with extension-count byte 0).
+ */
+static void check_hdr_disabled_base_only(const struct hermes_kms_edid_config *config,
+					 const char *what)
+{
+	u8 edid[HERMES_KMS_EDID_SIZE];
+
+	/*
+	 * This is the disabled path exactly: build the base block and stop.
+	 * No hermes_kms_append_hdr_extension() call, matching what the driver
+	 * hands DRM when hdr_enable is off.
+	 */
+	hermes_kms_build_edid(edid, 1, config);
+
+	check_structure(edid, what);
+	CHECK(edid[HERMES_KMS_EDID_EXT_COUNT_OFFSET] == 0,
+	      "%s: disabled path must leave extension count 0, got %u", what,
+	      edid[HERMES_KMS_EDID_EXT_COUNT_OFFSET]);
+}
+
 static void check_serials_differ(void)
 {
 	const struct hermes_kms_edid_config config = {
@@ -263,6 +524,45 @@ int main(void)
 	check_serials_differ();
 	check_physical_size();
 	check_color_depth();
+
+	{
+		u8 cta[HERMES_KMS_EDID_SIZE];
+
+		hermes_kms_build_edid_hdr_extension(cta);
+		check_cta_extension(cta, "CTA HDR extension");
+	}
+
+	/*
+	 * Sweep the two-block HDR checks across a small table of distinct
+	 * configs the same way check_envelope() sweeps envelopes[], so the
+	 * base/extension invariants (Properties 1-8) hold across the input
+	 * space rather than for a single hand-picked resolution.
+	 */
+	{
+		static const struct {
+			const char *what;
+			struct hermes_kms_edid_config config;
+		} hdr_configs[] = {
+#define HDR_CONFIG(w, h, hz) \
+	{ .max_width = (w), .max_height = (h), .max_refresh_hz = (hz) }
+			{ "hdr 1080p60", HDR_CONFIG(1920, 1080, 60) },
+			{ "hdr 1440p144", HDR_CONFIG(2560, 1440, 144) },
+			{ "hdr 4k120", HDR_CONFIG(3840, 2160, 120) },
+			{ "hdr 4k240", HDR_CONFIG(3840, 2160, 240) },
+#undef HDR_CONFIG
+		};
+		unsigned int j;
+
+		for (j = 0; j < sizeof(hdr_configs) / sizeof(hdr_configs[0]);
+		     j++) {
+			check_base_with_extension(&hdr_configs[j].config,
+						  hdr_configs[j].what);
+			check_invalid_base_refused(&hdr_configs[j].config,
+						   hdr_configs[j].what);
+			check_hdr_disabled_base_only(&hdr_configs[j].config,
+						     hdr_configs[j].what);
+		}
+	}
 
 	if (failures) {
 		fprintf(stderr, "%d EDID check(s) failed\n", failures);


### PR DESCRIPTION
## What this does

Makes a Hermes-KMS virtual output advertise HDR so a compositor recognizes it as
HDR-capable, behind a new load-time module parameter `hdr_enable` (default off).

On my setup (Fedora, KWin 6.7.4 on Wayland, AMD RX 7900 XT), a physical HDR
monitor reported and streamed HDR fine, but a Hermes-KMS virtual output always
reported `HDR: incapable`. With this change and `hdr_enable=1`, KWin recognizes
the virtual output as HDR-capable (the HDR toggle appears for it).

## Why it needs several pieces

I initially expected an EDID HDR Static Metadata block plus the
`HDR_OUTPUT_METADATA` connector property to be enough, but HDR stayed off. Tracing
KWin's `DrmOutput::computeCapabilities()` (`src/backends/drm/drm_output.cpp`)
showed it gates HDR behind a two-step chain, not a single signal:

- It sets `WideColorGamut` only if the connector has a `Colorspace` property
  advertising a BT2020 enum **and** the EDID reports `supportsBT2020()`.
- It sets `HighDynamicRange` only if `HDR_OUTPUT_METADATA` is present **and** the
  EDID reports `supportsPQ()` **and** `WideColorGamut` is already set.

So `WideColorGamut` is a prerequisite, and it needs both a `Colorspace` connector
property and a BT2020 Colorimetry block in the EDID. `modetest -M hermes-kms -c`
on the connector confirmed `HDR_OUTPUT_METADATA` was present but `Colorspace` was
missing, which is exactly why the gate was never satisfied.

## Changes

- **`kernel/hermes-kms/hermes_kms_edid.h`**: widen per-output EDID storage to two
  blocks; build a CTA-861 extension carrying an HDR Static Metadata Data Block
  (extended tag 0x06, PQ) and a BT2020 Colorimetry Data Block (extended tag 0x05);
  a finalize helper sets the base extension-count byte, fixes both checksums, and
  refuses to append to an invalid base. Named constants, no magic numbers, and
  everything stays valid under both the `__KERNEL__` and host-test branches.
- **`kernel/hermes-kms/hermes_kms.c`**: `hdr_enable` module parameter (`bool`,
  `0444`, default off); in `hermes_kms_output_modeset_init()`, gated by
  `hdr_enable`, attach `HDR_OUTPUT_METADATA` and create+attach the `Colorspace`
  property (`BT2020_RGB | DEFAULT`), each with failure propagation so the
  connector is not registered on error. No commit-time color handling is added —
  the existing atomic-helper connector state triplet stores the colorspace enum.
  A `pr_info` notes the untested-together `color_depth=10` dependency.
- **`tests/edid.c`**: byte-level checks for both data blocks, the two-block
  extension-count/checksum coupling, block/buffer sizes, the invalid-base guard,
  and that the HDR-disabled path is byte-identical to the previous single-block
  output. Runs under `make check`.
- **Docs**: `CHANGELOG.md`, `README.md`, `docs/driver-design.md` updated for the
  new parameter, the mechanisms it enables, and the `color_depth=10` note.

`hdr_enable` defaults off, and with it off the generated EDID is byte-identical to
before (single base block, no connector properties added), so existing behavior is
unchanged.

## Testing

- `make check` passes (host EDID byte-level tests, built with
  `-std=c11 -Wall -Wextra -Werror -pedantic`).
- Kernel module builds against 7.1.x headers;
  `drm_mode_create_hdmi_colorspace_property`,
  `drm_connector_attach_colorspace_property`, and the
  `DRM_MODE_COLORIMETRY_BT2020_RGB` / `DRM_MODE_COLORIMETRY_DEFAULT` enums are
  standard DRM core symbols and resolved without a version guard.
- On hardware (with `hdr_enable=1 color_depth=10`): `edid-decode` on the
  connector's sysfs EDID shows the HDR Static Metadata block with valid base and
  extension checksums and no warnings/errors; `modetest -M hermes-kms -c` shows
  both `HDR_OUTPUT_METADATA` and `Colorspace` on the connector; KWin then exposes
  an HDR toggle on the virtual output (it did not before).

## Scope and current limitations

- I've verified the driver-side advertisement (both EDID blocks + both connector
  properties, and KWin recognizing the output as HDR-capable). I have **not**
  fully validated an end-to-end HDR *stream* yet. When I enable HDR for the
  virtual output, my capture/streaming client still tags the stream as SDR, which
  looks like a colorspace-detection issue on the consumer side rather than in this
  driver — I'm treating that as separate follow-up work outside this change.
- Whether `color_depth=10` must be set alongside `hdr_enable` for a given
  compositor is called out in the docs as an untested-together dependency.
- If a compositor still reports HDR-incapable after all of the above plus
  `color_depth=10`, CRTC color-management properties would be the next area to
  look at; that's intentionally out of scope here.

Happy to adjust anything — naming, the parameter default, splitting commits, or the
documentation — whatever fits the project best. Thanks for maintaining Hermes-KMS.

## AI assistance disclosure

This contribution was developed with AI assistance (an AI coding agent). The AI
helped investigate the root cause, write the EDID construction and connector-property
code, the host tests, and the documentation, and drafted this PR description. I
directed the work, reviewed all of the changes, and validated the results myself on
real hardware (the `edid-decode`, `modetest`, and KWin behavior described above). I
take responsibility for the correctness and licensing of this contribution. Flagging
the AI involvement in the interest of transparency — happy to walk through any part
of the change or the reasoning behind it.
